### PR TITLE
adding poylmer dependency to the pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   browser: any
   chrome: any
   compiler_unsupported: any
+  polymer: any
 dev_dependencies:
   args: any
   grinder:

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -24,25 +24,9 @@ void init(GrinderContext context) {
 
 void packages(GrinderContext context) {
   // copy from ./packages to ./app/packages
-  List<String> packages = [
-      'ace',
-      'analyzer_experimental',
-      'compiler_unsupported',
-      'chrome',
-      'meta',
-      'stack_trace',
-      'browser',
-      'js',
-      'unittest',
-      'logging',
-      'path',
-      'unmodifiable_collection'];
-
-  for (String dirName in packages) {
-    copyDirectory(
-        joinDir(Directory.current, ['packages', dirName]),
-        joinDir(Directory.current, ['app', 'packages', dirName]));
-  }
+  copyDirectory(
+      joinDir(Directory.current, ['packages']),
+      joinDir(Directory.current, ['app', 'packages']));
 }
 
 void compile(GrinderContext context) {


### PR DESCRIPTION
This includes the polymer dependency and makes sure that all the packages it uses are copied into the app/packages directory. There will need to be some investigation I think until we can get a dart polymer helloworld running in a chrome app.
