### PR TITLE
create a small UI that allows a developer to run the test suite when the...

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,16 @@ In order to run the tests, we modify the html entry-point slightly to point to
 `app/spark_test.dart`. This source file references the entire spark app as
 well as the unit tests for the app.
 
-Run `./grind mode-test` to switch the app over to including tests, and
-`./grind mode-notest` to switch it back before commit.
+Run
+
+    ./grind mode-test
+
+to switch the app over to including tests, and
+
+    ./grind mode-notest
+
+to switch it back before commit.
 
 Ideally, the application might include it's own tests. There's currently an
 issue with the compiled javascript size if we do that however. It's still a work
-in progress to make it easier to run the tests, and to get them running in a
-continuous integration environment.
+in progress to get the tests running in a continuous integration environment.

--- a/app/spark_test.dart
+++ b/app/spark_test.dart
@@ -1,15 +1,148 @@
-
+/**
+ * This custom version of Spark allows us to run the suite of tests, either in
+ * a manual or an automated fashion.
+ */
 library spark_test;
 
-import 'spark.dart' as spark;
-import 'test/all.dart' as all_tests;
+import 'dart:async';
+import 'dart:html';
 
+import 'package:chrome/app.dart' as chrome;
+import 'package:logging/logging.dart';
+
+import 'spark.dart' as spark;
+import 'test/all.dart' as tests;
+
+Logger testLogger = new Logger('spark.tests');
+
+/**
+ * Start the app, show the test UI, and connect to a test server if one is
+ * available.
+ */
 void main() {
   SparkTest app = new SparkTest();
-
-  app.runTests();
+  app.showTestUI();
+  try {
+    // TODO(devoncarew): this throws a strange JS interop exception right now
+    app.connectToListener();
+  } catch (e) {
+    print(e);
+  }
 }
 
+/**
+ * A custom subclass of Spark with tests built-in.
+ */
 class SparkTest extends spark.Spark {
-  void runTests() => all_tests.runTests();
+  SparkTest() {
+    print('Running Spark in test mode');
+  }
+
+  void connectToListener() {
+    // try to connect to a pre-defined port
+    TestListenerClient.connect()
+        .then(runTests)
+        .catchError((e) => print(e));
+  }
+
+  void runTests(TestListenerClient testClient) {
+    print('Connected to test listener on port ${testClient.port}');
+
+    testLogger.onRecord.listen((LogRecord record) {
+      testClient.log(
+          '[${record.loggerName} '
+          '${record.level.toString().toLowerCase()}] '
+          '${record.message}');
+    });
+
+    tests.runTests().then((bool success) {
+      testClient.log('test exit code: ${(success ? 0 : 1)}');
+
+      // TODO: what I really want here is to programmatically quit the app
+      chrome.app.window.current.close();
+    });
+  }
+
+  /**
+   * Display a UI to drive unit tests. This floats over the window's content.
+   */
+  void showTestUI() {
+    DivElement div = new DivElement();
+    div.style.zIndex = '100';
+    div.style.position = 'fixed';
+    div.style.bottom = '0px';
+    div.style.marginBottom = '0.5em';
+    div.style.marginLeft = '0.5em';
+    div.style.background = 'gray';
+    div.style.borderRadius = '4px';
+    div.style.opacity = '0.7';
+
+    ButtonElement button = new ButtonElement();
+    button.text = "Run Tests";
+    div.nodes.add(button);
+
+    SpanElement status = new SpanElement();
+    status.style.marginRight = '0.5em';
+    status.style.display = 'none';
+    div.nodes.add(status);
+
+    button.onClick.listen((e) {
+      div.style.background = 'green';
+      status.style.display = 'inline';
+      status.text = '';
+      button.disabled = true;
+      tests.runTests().then((bool success) {
+        button.disabled = false;
+      });
+    });
+
+    testLogger.onRecord.listen((LogRecord record) {
+      if (record.level > Level.INFO) {
+        div.style.background = 'red';
+      }
+
+      status.text =
+          '[${record.loggerName} '
+          '${record.level.toString().toLowerCase()}] '
+          '${record.message}';
+    });
+
+    document.body.nodes.add(div);
+  }
+}
+
+/**
+ * A class to connect to an existing test listener, and write test output to it.
+ */
+class TestListenerClient {
+  static const int DEFAULT_TESTPORT = 5120;
+
+  chrome.TcpClient _tcpClient;
+
+  /**
+   * Try to connect to a test listener on the given port, and return a new
+   * instance of [TestListenerClient] on success.
+   */
+  static Future<TestListenerClient> connect([int port = DEFAULT_TESTPORT]) {
+    chrome.TcpClient tcpClient = new chrome.TcpClient('127.0.0.1', port);
+
+    return tcpClient.connect().then((bool success) {
+      if (success) {
+        return new TestListenerClient._(tcpClient);
+      } else {
+        throw new Exception('no listener available on port ${port}');
+      }
+    });
+  }
+
+  TestListenerClient._(this._tcpClient);
+
+  int get port => _tcpClient.port;
+
+  /**
+   * Send a line of output to the test listener.
+   */
+  void log(String str) {
+    _tcpClient.send('${str}\n');
+  }
 }


### PR DESCRIPTION
... app is in test mode

This CL surfaces a small UI to allow a developer to run tests locally. It's essentially a small button in the bottom left corner that floats on top of the rest of the UI.

![screen shot 2013-09-26 at 3 16 13 pm](https://f.cloud.github.com/assets/1269969/1222096/7cd8be46-26f9-11e3-9c87-65094bf2d4c8.png)

When clicked, any test output gets logged to the developer console, and the UI's updated w/ the test results:

![screen shot 2013-09-26 at 3 16 20 pm](https://f.cloud.github.com/assets/1269969/1222106/a1512e02-26f9-11e3-9f9f-d3446f2a472d.png)

There's also plumbing in here for automatically trying to connect to a test listener service on startup (this only happens when running in test mode). If one is found, the tests are run automatically and test results are piped over the socket connection.

My next CL will hopefully have a working test listener service. That tool would listen on a certain port, start a Chrome instance running the app, listen for test results, and then either wait for the process to exit or terminate it itself. This service would then be runs on our bots ==> should give us test coverage for each commit and branch for spark.

@keertip @dinhviethoa
