### PR TITLE
changing the bootstrap script to automatically add .precompiled.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ dist/
 *.js.map
 *.js.deps
 app/spark.dart.js
+app/spark_test.dart.js
 app/spark.dart.precompiled.js
+app/spark_test.dart.precompiled.js
 docs/
+build/

--- a/app/spark.html
+++ b/app/spark.html
@@ -72,7 +72,7 @@
   <!-- this starts the Dart VM in Dartium, and injects spark.dart.js otherwise -->
   <script src="spark_bootstrap.js" defer></script>
 
-  <script type="application/dart" src="spark.dart" defer></script>
+  <script type="application/dart" src="spark_test.dart" defer></script>
   <sp-button>I'm a polymer button</sp-button>
 </body>
 

--- a/app/spark_bootstrap.js
+++ b/app/spark_bootstrap.js
@@ -2,11 +2,21 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-if (navigator.webkitStartDart) {
-  navigator.webkitStartDart();
-} else {
-  var script = document.createElement('script');
-  // Point the script to the compiled CSP compatible output for Spark.
-  script.src = 'spark.html_bootstrap.dart.precompiled.js';
-  document.body.appendChild(script);
-}
+(function() {
+  if (navigator.webkitStartDart) {
+    navigator.webkitStartDart();
+  } else {
+    var scripts = document.getElementsByTagName("script");
+
+    for (var i = 0; i < scripts.length; ++i) {
+      if (scripts[i].type == "application/dart") {
+        if (scripts[i].src && scripts[i].src != '') {
+          var script = document.createElement('script');
+          script.src = scripts[i].src.replace(/\.dart(?=\?|$)/, '.dart.precompiled.js');
+          document.currentScript = script;
+          scripts[i].parentNode.replaceChild(script, scripts[i]);
+        }
+      }
+    }
+  }
+})();


### PR DESCRIPTION
This (temporarily) changes the default mode of the app to testing. This will make it easier for developers - they'll always run in test mode, and won't have to worry about not committing that delta to spark.html. The build system will change the app over to none test mode before building.

We'll try and reconcile test mode, building for polymer, and developing vs. deployment in the medium term -

@dinhviethoa 
