### PR TITLE
Fixed: double-execution of webkitStartDart() used to break polymer-element instantiations.

### DIFF
--- a/app/spark_bootstrap.js
+++ b/app/spark_bootstrap.js
@@ -3,8 +3,14 @@
 // license that can be found in the LICENSE file.
 
 (function() {
-  if (navigator.webkitStartDart) {
-    navigator.webkitStartDart();
+    // NOTE: This is already done in polymer/boot.js, and this attempt to
+    // execute it the second time breaks polymer-element instantiations.
+    // This is in a transient state: boot.js is going away soon, and so it
+    // the requirement to run webkitStartDart(). By Dart 1.0 both should be
+    // gone. However, depending on which goes first, this might need to be
+    // uncommented for a brief period.
+    // TODO: Remove this completely after Dart 1.0.
+    // navigator.webkitStartDart();
   } else {
     var scripts = document.getElementsByTagName("script");
 

--- a/app/spark_bootstrap.js
+++ b/app/spark_bootstrap.js
@@ -3,13 +3,14 @@
 // license that can be found in the LICENSE file.
 
 (function() {
+  if (navigator.webkitStartDart) {
     // NOTE: This is already done in polymer/boot.js, and this attempt to
     // execute it the second time breaks polymer-element instantiations.
     // This is in a transient state: boot.js is going away soon, and so it
     // the requirement to run webkitStartDart(). By Dart 1.0 both should be
     // gone. However, depending on which goes first, this might need to be
     // uncommented for a brief period.
-    // TODO: Remove this completely after Dart 1.0.
+    // TODO(sergeygs): Remove this completely after Dart 1.0.
     // navigator.webkitStartDart();
   } else {
     var scripts = document.getElementsByTagName("script");


### PR DESCRIPTION
webkitStartDart() is already invoked from polymer/boot.js, which spark.html includes. Second invocation was somehow breaking the process of instantiating polymer-elements: the elements were left uninstantiated. 
