### PR TITLE
pegging the version of chrome_gen that we use

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   analyzer_experimental: any
   browser: any
   chrome: any
-  chrome_gen: '>=0.0.5'
+  chrome_gen: 0.0.5
   compiler_unsupported: any
   intl: any
   logging: any


### PR DESCRIPTION
The next version of chrome_gen that comes out will be a breaking change from the POV of the files API. We want to depend on 0.0.5 explicitly, and move to 0.0.6 once we've adjusted to the changed APIs.
