### PR TITLE
re-swizzle build

### DIFF
--- a/ide/tool/drone_io.sh
+++ b/ide/tool/drone_io.sh
@@ -6,9 +6,13 @@ sudo start xvfb
 pub install
 ./grind setup          
 
-# run tests
-./grind deploy-test
-dart tool/test_runner.dart --dartium
-
 # build the archive
 ./grind archive
+
+./grind deploy-test
+
+# run tests on dartium
+dart tool/test_runner.dart --dartium
+
+# run tests on chrome
+dart tool/test_runner.dart --chrome

--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -21,11 +21,12 @@ void main() {
   defineTask('mode-notest', taskFunction: (c) => _changeMode(c, false));
   defineTask('mode-test', taskFunction: (c) => _changeMode(c, true));
 
+  defineTask('compile', taskFunction: compile, depends : ['setup']);
   defineTask('deploy', taskFunction: deploy, depends : ['setup', 'mode-notest']);
   defineTask('deploy-test', taskFunction: deployTest, depends : ['setup', 'mode-test']);
 
   defineTask('docs', taskFunction : docs, depends : ['setup']);
-  defineTask('archive', taskFunction : archive, depends : ['deploy']);
+  defineTask('archive', taskFunction : archive, depends : ['mode-notest', 'compile']);
   defineTask('release', taskFunction : release, depends : ['deploy']);
 
   defineTask('clean', taskFunction: clean);
@@ -59,6 +60,15 @@ void setup(GrinderContext context) {
 }
 
 /**
+ * Compile the two Spark entry-points.
+ */
+void compile(GrinderContext context) {
+  _dart2jsCompile(context, new Directory('app'), 'spark.dart');
+  context.log('');
+  _dart2jsCompile(context, new Directory('app'), 'spark_test.dart');
+}
+
+/**
  * Copy all source to `build/deploy`. Do a polymer deploy to `build/deploy-out`.
  * This builds the regular (non-test) version of the app.
  */
@@ -69,7 +79,7 @@ void deploy(GrinderContext context) {
   _polymerDeploy(context, sourceDir, destDir);
 
   ['spark.html_bootstrap.dart', 'spark_polymer.html_bootstrap.dart']
-      .forEach((e) => _dart2jsCompile(context, joinDir(destDir, ['web']), e));
+      .forEach((e) => _dart2jsCompile(context, joinDir(destDir, ['web']), e, true));
 }
 
 /**
@@ -83,7 +93,7 @@ void deployTest(GrinderContext context) {
   _polymerDeploy(context, sourceDir, destDir);
 
   ['spark.html_bootstrap.dart', 'spark_polymer.html_bootstrap.dart']
-      .forEach((e) => _dart2jsCompile(context, joinDir(destDir, ['web']), e));
+      .forEach((e) => _dart2jsCompile(context, joinDir(destDir, ['web']), e, true));
 }
 
 // Creates a release build to be uploaded to Chrome Web Store.
@@ -209,7 +219,8 @@ void _polymerDeploy(GrinderContext context, Directory sourceDir, Directory destD
       workingDirectory: sourceDir.path);
 }
 
-void _dart2jsCompile(GrinderContext context, Directory target, String filePath) {
+void _dart2jsCompile(GrinderContext context, Directory target, String filePath,
+                     [bool removeSymlinks = false]) {
   runSdkBinary(context, 'dart2js', arguments: [
      joinDir(target, [filePath]).path,
      '--package-root=packages',
@@ -222,12 +233,14 @@ void _dart2jsCompile(GrinderContext context, Directory target, String filePath) 
   _runCommandSync(context, 'rm -f ${joinFile(target, ['${filePath}.js.deps']).path}');
   _runCommandSync(context, 'rm -f ${joinFile(target, ['${filePath}.js.map']).path}');
 
-  // de-symlink the directory
-  _removePackagesLinks(context, target);
+  if (removeSymlinks) {
+    // de-symlink the directory
+    _removePackagesLinks(context, target);
 
-  copyDirectory(
-      joinDir(target, ['..', '..', '..', 'packages']),
-      joinDir(target, ['packages']));
+    copyDirectory(
+        joinDir(target, ['..', '..', '..', 'packages']),
+        joinDir(target, ['packages']));
+  }
 
   _printSize(context,  joinFile(target, ['${filePath}.precompiled.js']));
 }

--- a/ide/tool/test_runner.dart
+++ b/ide/tool/test_runner.dart
@@ -47,22 +47,24 @@ void main() {
   }
 
   if (results['chrome'] || results['chrome-stable']) {
-    appPath = 'build/deploy-test-out/web';
+    appPath = 'app';
+    //appPath = 'build/deploy-test-out/web';
     browserPath = _chromeStablePath();
   }
 
   if (results['chrome-dev']) {
-    appPath = 'build/deploy-test-out/web';
+    appPath = 'app';
+    //appPath = 'build/deploy-test-out/web';
     browserPath = _chromeDevPath();
   }
 
-  if (results['appPath'] != null) {
-    appPath = results['appPath'];
-  }
-
-  if (results['browserPath'] != null) {
-    browserPath = results['browserPath'];
-  }
+//  if (results['appPath'] != null) {
+//    appPath = results['appPath'];
+//  }
+//
+//  if (results['browserPath'] != null) {
+//    browserPath = results['browserPath'];
+//  }
 
   if (appPath == null || browserPath == null) {
     _printUsage(parser);
@@ -122,8 +124,8 @@ ArgParser _createArgsParser() {
   parser.addFlag('chrome-dev',
       help: 'run in chrome dev, test the app in build/deploy-test-out/web/', negatable: false);
 
-  parser.addOption('appPath', help: 'the application path to run');
-  parser.addOption('browserPath', help: 'the path to chrome');
+//  parser.addOption('appPath', help: 'the application path to run');
+//  parser.addOption('browserPath', help: 'the path to chrome');
 
   return parser;
 }


### PR DESCRIPTION
This:
- re-adds a compile task, which just does a simple dart2js compile of the two dart entrypoints
- changes the archive task to archive the non-polymer version of the app
- changes our test runner to prefer running the dart2js (non-polymer) app

It also enables the chrome+dart2js tests on the build bot.

@dinhviethoa @ussuri 
