### PR TITLE
Added build.dart to make Polymer iterations in Dart Editor easier.

### DIFF
--- a/ide/build.dart
+++ b/ide/build.dart
@@ -10,8 +10,7 @@ void main() {
         'update', taskFunction: update))
     ..addTask(new grind.GrinderTask(
         'lint', taskFunction: lint, depends: ['update']))
-    ..start(['update', 'lint']);
-  exitCode = 1;
+    ..start(['lint']);
 }
 
 void update(context) {


### PR DESCRIPTION
@devoncarew

Essentially just pulls in the changes under widgets/ into ide/app/packages, allowing quick debugging of the uncompiled app.

Still needs to be run manually every time 'widgets/' change, but that can be done via the context menu or Run button of the editor without switching to command line and back.
