### PR TITLE
fix a warning and add a question

### DIFF
--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -41,7 +41,7 @@ class Workspace implements Container {
   bool get isTopLevel => false;
   String persistToToken() => path;
 
-  // TODO: can we remove this? Should users migrate to path or token/
+  // TODO: we should migrarte users to path or perhaps persistToToken()
   String get fullPath => '';
 
   Container get parent => null;


### PR DESCRIPTION
@keertip and @dinhviethoa 

This fixes a warning in Workspace for an unimplemented member. Hoa, how is fullPath being used? Would it be appropriate to remove it and replace references to it with `path` or `persistToToken()`?

`path` is the full path of the resource, from the POV of the workspace. This is not related to where the resource is on disk.

`persistToToken()` is used to get an opaque token that can be used to get a reference to a Resource. So, it's used for things like persisting and restoring a Resource reference across sessions.

Alternatively, should we expose the FileEntry directly?
