### PR TITLE
css tweaks to the new tab view

### DIFF
--- a/ide/app/lib/ui/widgets/tabview.css
+++ b/ide/app/lib/ui/widgets/tabview.css
@@ -9,7 +9,6 @@
   top: 0;
 }
 
-
 .tabview-tabbar {
   background: white;
   border-bottom: 1px solid #CCC;
@@ -59,11 +58,9 @@
   box-sizing: border-box;
   cursor: pointer;
   display: inline-flex;
-  font-family: sans-serif;
-  font-size: 85%;
   margin-top: 4px;
   margin-right: 4px;
-  padding: 2px 10px 2px 10px;
+  padding: 2px 6px 2px 10px;
   -webkit-user-select: none;
   vertical-align: bottom;
   z-index: 100;
@@ -82,13 +79,13 @@
   border: 1px solid #CCC;
   border-bottom: 1px solid white;
   margin-top: 5px;
-  margin-bottom: -1px;
+  margin-bottom: 0;
   padding-bottom: 1px;
   position: relative;
 }
 
 .tabview-tablabel:hover .tabview-tablabel-caption {
-  text-decoration: underline;
+  
 }
 
 .tabview-tablabel-caption {
@@ -99,28 +96,30 @@
 }
 
 .tabview-tablabel-closebutton {
-  color: white;
+  opacity: 0;
   display: none;
   margin-left: 6px;
-  margin-right: -2px;
-  margin-top: -1px;
-  opacity: 0;
-  text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+  margin-bottom: 2px;
+  font-size: 18px;
 }
 
 .tabview-tablabel-closable .tabview-tablabel-closebutton {
   display: block;
 }
+
 .tabview-tablabel-active .tabview-tablabel-closebutton {
-  opacity: 1;
+  opacity: 0.2;
 }
 
 .tabview-tablabel:hover .tabview-tablabel-closebutton {
-  opacity: 1;
+  opacity: 0.2;
 }
 
 .tabview-tablabel-closebutton:hover {
-  color: #960;
+  opacity: 0.4;
+}
+.tabview-tablabel:hover .tabview-tablabel-closebutton:hover {
+  opacity: 0.4;
 }
 
 .tabview-workspace {

--- a/ide/app/lib/ui/widgets/tabview.dart
+++ b/ide/app/lib/ui/widgets/tabview.dart
@@ -21,7 +21,7 @@ class Tab {
 
   DivElement _label;
   DivElement _labelCaption;
-  DivElement _closeButton;
+  ButtonElement _closeButton;
 
   Tab(this.tabView, this.component, {closable: true}) {
     this.component.classes.add('tabview-tabcomponent');
@@ -35,8 +35,10 @@ class Tab {
 
     _labelCaption = new DivElement()..classes.add('tabview-tablabel-caption');
 
-    _closeButton = new DivElement()
-        ..classes.add('tabview-tablabel-closebutton');
+    _closeButton = new ButtonElement()
+        ..classes.add('tabview-tablabel-closebutton')
+        ..classes.add('close')
+        ..type = 'button';
     _closeButton.appendHtml('&times;');
     _closeButton.onClick.listen((e) {
       tabView.remove(this);


### PR DESCRIPTION
Some tweaks to the css for the new tab view:
- change to use the same font as in the files view. There were too many different fonts on the screen - it was a bit jarring.
- tweak the close button to be closer to the bootstrap default
- remove the underline decoration - the tab header seemed busy, and the cursor change gives the user a good enough indication that the tab is actionable

![screen shot 2013-11-15 at 12 05 22 pm](https://f.cloud.github.com/assets/1269969/1553287/4e7e78ec-4e31-11e3-8866-1b0c68e84336.png)
