### PR TITLE
Include all required CSS dependencies from spark.css, not spark.html

### DIFF
--- a/ide/app/spark.css
+++ b/ide/app/spark.css
@@ -2,6 +2,14 @@
 /* All rights reserved.  Use of this source code is governed by a BSD-style */
 /* license that can be found in the LICENSE file. */
 
+
+@import url("packages/bootjack/css/bootstrap.css");
+@import url("packages/bootjack/css/bootstrap-theme.css");
+@import url("lib/ui/widgets/splitview.css");
+@import url("lib/ui/widgets/listview.css");
+@import url("lib/ui/widgets/treeview.css");
+@import url("lib/ui/widgets/tabview.css");
+  
 body {
   bottom: 0;
   display: flex;

--- a/ide/app/spark.html
+++ b/ide/app/spark.html
@@ -10,12 +10,6 @@
   <title>Spark</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <link rel="stylesheet" href="packages/bootjack/css/bootstrap.css">
-  <link rel="stylesheet" href="packages/bootjack/css/bootstrap-theme.css">
-  <link rel="stylesheet" href="lib/ui/widgets/splitview.css">
-  <link rel="stylesheet" href="lib/ui/widgets/listview.css">
-  <link rel="stylesheet" href="lib/ui/widgets/treeview.css">
-  <link rel="stylesheet" href="lib/ui/widgets/tabview.css">
   <link rel="stylesheet" href="spark.css">
 
   <!-- template for FileItemCell -->


### PR DESCRIPTION
@dinhviethoa @devoncarew @keertip: what do you think (all of you created the edited lines)? Why did you include all of these from the HTML in the first place? Is that the general practice?
