### PR TITLE
Move `EditorManager` to `ace.dart`

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -7,31 +7,34 @@
  */
 library spark.ace;
 
-import 'dart:html';
+import 'dart:async';
+import 'dart:convert' show JSON;
+import 'dart:html' show Element;
 import 'dart:js' as js;
 
 import 'package:ace/ace.dart' as ace;
 
+import 'editors.dart';
+import 'preferences.dart';
 import 'workspace.dart' as workspace;
-
-export 'package:ace/ace.dart' show EditSession;
 
 /**
  * A wrapper around an Ace editor instance.
  */
-class AceEditor {
+class AceEditor implements Editor {
   static final THEMES = ['ambiance', 'monokai', 'pastel_on_dark', 'textmate'];
 
   /// The element to put the editor in.
-  final Element parentElement;
+  final Element rootElement;
 
   ace.Editor _aceEditor;
   workspace.File _file;
+  AceEditorState _state;
 
   static bool get available => js.context['ace'] != null;
 
-  AceEditor(this.parentElement) {
-    _aceEditor = ace.edit(parentElement);
+  AceEditor(this.rootElement) {
+    _aceEditor = ace.edit(rootElement);
     _aceEditor.readOnly = true;
 
     // Fallback
@@ -59,16 +62,252 @@ class AceEditor {
     return session;
   }
 
-  void switchTo(ace.EditSession session) {
-    if (session == null) {
+  AceEditorState get state => _state;
+  void set state(AceEditorState state) {
+    _state = state;
+    if (state == null) {
       _aceEditor.session = ace.createEditSession('', new ace.Mode('ace/mode/text'));
       _aceEditor.readOnly = true;
     } else {
-      _aceEditor.session = session;
+      state.withSession().then((state) {
+        if (state != _state) return;
+        _aceEditor.session = state.session;
 
-      if (_aceEditor.readOnly) {
-        _aceEditor.readOnly = false;
+        if (_aceEditor.readOnly) {
+          _aceEditor.readOnly = false;
+        }
+      });
+    }
+  }
+}
+
+
+/**
+ * This class tracks the state associated with each open editor.
+ */
+class AceEditorState implements EditorState {
+  AceEditor editor;
+  AceEditorManager manager;
+  workspace.File file;
+  ace.EditSession session;
+
+  int scrollTop = 0;
+  bool _dirty = false;
+
+  AceEditorState(this.editor, this.manager);
+
+  bool fromMap(workspace.Workspace workspace, Map m) {
+    workspace.File f = workspace.restoreResource(m['file']);
+
+    if (f == null) {
+      return false;
+    } else {
+      file = f;
+      scrollTop = m['scrollTop'];
+      return true;
+    }
+  }
+
+  bool get dirty => _dirty;
+
+  set dirty(bool value) {
+    if (_dirty != value) {
+      _dirty = value;
+      if (_dirty) {
+        manager._startSaveTimer();
       }
     }
+  }
+
+  bool get hasSession => session != null;
+
+  void save() {
+    if (dirty) {
+      file.setContents(session.value);
+      dirty = false;
+    }
+  }
+
+  /**
+   * Return a [Map] representing the persistable state of this editor. This map
+   * can later be passed into [AceEditorState.fromMap] to restore the state.
+   */
+  Map toMap() {
+    Map m = {};
+    m['file'] = file.persistToToken();
+    m['scrollTop'] = session == null ? scrollTop : session.scrollTop;
+    return m;
+  }
+
+  Future<AceEditorState> withSession() {
+    if (hasSession) {
+      return new Future.value(this);
+    } else {
+      return file.getContents().then((text) {
+        session = editor.createEditSession(text, file.name);
+        session.scrollTop = scrollTop;
+        session.onChange.listen((delta) => dirty = true);
+        return this;
+      });
+    }
+  }
+}
+
+
+/**
+ * Manage a list of open editors.
+ */
+class AceEditorManager implements EditorProvider {
+  final AceEditor editor;
+  final workspace.Workspace _workspace;
+
+  final PreferenceStore _prefs;
+
+  final List<AceEditorState> _editorStates = [];
+
+  final Completer<bool> _loadedCompleter = new Completer.sync();
+  AceEditorState _currentState;
+
+  final StreamController<workspace.File> _selectedController =
+      new StreamController.broadcast();
+
+  AceEditorManager(this._workspace, this.editor, this._prefs) {
+    _workspace.whenAvailable().then((_) {
+      _prefs.getValue('editorStates').then((String data) {
+        if (data != null) {
+          for (Map m in JSON.decode(data)) {
+            workspace.File f = _workspace.restoreResource(m['file']);
+            openOrSelect(f, switching: false);
+          }
+          _loadedCompleter.complete(true);
+        }
+      });
+    });
+  }
+
+  workspace.File get currentFile =>
+      _currentState != null ? _currentState.file : null;
+
+  Iterable<workspace.File> get files => _editorStates.map((s) => s.file);
+  Future<bool> get loaded => _loadedCompleter.future;
+
+  Stream<workspace.File> get onSelectedChange => _selectedController.stream;
+
+  bool get dirty => _currentState == null ? false : _currentState.dirty;
+
+  void _insertState(AceEditorState state) => _editorStates.add(state);
+
+  bool _removeState(AceEditorState state) => _editorStates.remove(state);
+
+  /**
+   * This will open the given [File]. If this file is already open, it will
+   * instead be made the active editor.
+   */
+  void openOrSelect(workspace.File file, {switching: true}) {
+    if (file == null) return;
+    AceEditorState state = _getStateFor(file);
+
+    if (state == null) {
+      state = new AceEditorState(editor, this);
+      state.file = file;
+      _insertState(state);
+    }
+
+    if (switching)
+      _switchState(state);
+  }
+
+  bool isFileOpend(workspace.File file) => _getStateFor(file) != null;
+
+  void saveAll() => _saveAll();
+
+  void close(workspace.File file) {
+    AceEditorState state = _getStateFor(file);
+
+    if (state != null) {
+      int index = _editorStates.indexOf(state);
+      _removeState(state);
+
+      if (state.dirty) {
+        state.save();
+      }
+
+      if (_currentState == state) {
+        // Switch to the next editor.
+        if (_editorStates.isEmpty) {
+          _switchState(null);
+        } else if (index < _editorStates.length){
+          _switchState(_editorStates[index]);
+        } else {
+          _switchState(_editorStates[index - 1]);
+        }
+      }
+
+      persistState();
+    }
+  }
+
+  void persistState() {
+    var stateData = _editorStates.map((state) => state.toMap()).toList();
+    _prefs.setValue('editorStates', JSON.encode(stateData));
+  }
+
+  AceEditorState _getStateFor(workspace.File file) {
+    for (AceEditorState state in _editorStates) {
+      if (state.file == file) {
+        return state;
+      }
+    }
+
+    return null;
+  }
+
+  void _switchState(AceEditorState state) {
+    if (_currentState != state) {
+      _currentState = state;
+      _selectedController.add(currentFile);
+      if (state == null) {
+          editor.state = null;
+          persistState();
+      } else {
+        state.withSession().then((state) {
+          // Test if other state have been set before this state is appiled.
+          if (state != _currentState) return;
+          _selectedController.add(currentFile);
+          editor.state = state;
+          persistState();
+        });
+      }
+    }
+  }
+
+  Timer _timer;
+
+  void _startSaveTimer() {
+    if (_timer != null) _timer.cancel();
+
+    _timer = new Timer(new Duration(seconds: 2), () => _saveAll());
+  }
+
+  void _saveAll() {
+    if (_timer != null) {
+      _timer.cancel();
+      _timer = null;
+    }
+
+    // TODO: start a workspace change event; this might modify multiple files
+    _editorStates.forEach((e) => e.save());
+    // TODO: end the workspace change event
+  }
+
+  // EditorProvider
+  AceEditor createEditorForFile(workspace.Resource file) {
+    openOrSelect(file);
+    return editor;
+  }
+
+  void selectFileForEditor(AceEditor editor, workspace.Resource file) {
+    AceEditorState state = _getStateFor(file);
+    _switchState(state);
   }
 }

--- a/ide/app/lib/editorarea.dart
+++ b/ide/app/lib/editorarea.dart
@@ -20,7 +20,7 @@ class EditorTab extends Tab {
   final AceEditor editor;
   EditorTab(EditorArea parent, AceEditor editor, this.file)
       : editor = editor,  // FIXME(ikarienator): cannot use this.editor style.
-        super(parent, page: editor.parentElement) {
+        super(parent, page: editor.rootElement) {
     label = file.name;
   }
 }

--- a/ide/app/lib/editors.dart
+++ b/ide/app/lib/editors.dart
@@ -8,11 +8,8 @@
  */
 library spark.editors;
 
-import 'dart:async';
-import 'dart:convert' show JSON;
+import 'dart:html' as html;
 
-import 'ace.dart';
-import 'preferences.dart';
 import 'workspace.dart';
 
 /**
@@ -20,236 +17,30 @@ import 'workspace.dart';
  * TODO(ikarienator): Abstract [AceEditor] so we can support more editor types.
  */
 abstract class EditorProvider {
-  AceEditor createEditorForFile(Resource file);
-  void selectFileForEditor(AceEditor editor, Resource file);
+  Editor createEditorForFile(Resource file);
+  void selectFileForEditor(Editor editor, Resource file);
   void close(Resource file);
 }
 
+abstract class Editor {
+  /// The root element to put the editor in.
+  html.Element get rootElement;
 
-/**
- * Manage a list of open editors.
- */
-class EditorManager implements EditorProvider {
-  final Workspace _workspace;
-  final AceEditor _aceEditor;
+  /// Gets/sets the current session.
+  EditorState state;
 
-  final PreferenceStore _prefs;
-
-  final List<_EditorState> _editorStates = [];
-
-  final Completer<bool> _loadedCompleter = new Completer.sync();
-  _EditorState _currentState;
-
-  final StreamController<File> _selectedController =
-      new StreamController.broadcast();
-
-  EditorManager(this._workspace, this._aceEditor, this._prefs) {
-    _workspace.whenAvailable().then((_) {
-      _prefs.getValue('editorStates').then((String data) {
-        if (data != null) {
-          for (Map m in JSON.decode(data)) {
-            File f = _workspace.restoreResource(m['file']);
-            openOrSelect(f, switching: false);
-          }
-          _loadedCompleter.complete(true);
-        }
-      });
-    });
-  }
-
-  File get currentFile => _currentState != null ? _currentState.file : null;
-
-  Iterable<File> get files => _editorStates.map((s) => s.file);
-  Future<bool> get loaded => _loadedCompleter.future;
-
-  Stream<File> get onSelectedChange => _selectedController.stream;
-
-  bool get dirty => _currentState == null ? false : _currentState.dirty;
-
-  void _insertState(_EditorState state) => _editorStates.add(state);
-
-  bool _removeState(_EditorState state) => _editorStates.remove(state);
-
-  /**
-   * This will open the given [File]. If this file is already open, it will
-   * instead be made the active editor.
-   */
-  void openOrSelect(File file, {switching: true}) {
-    if (file == null) return;
-    _EditorState state = _getStateFor(file);
-
-    if (state == null) {
-      state = new _EditorState.fromFile(this, file);
-      _insertState(state);
-    }
-
-    if (switching)
-      _switchState(state);
-  }
-
-  bool isFileOpend(File file) => _getStateFor(file) != null;
-
-  void saveAll() => _saveAll();
-
-  void close(File file) {
-    _EditorState state = _getStateFor(file);
-
-    if (state != null) {
-      int index = _editorStates.indexOf(state);
-      _removeState(state);
-
-      if (state.dirty) {
-        state.save();
-      }
-
-      if (_currentState == state) {
-        // Switch to the next editor.
-        if (_editorStates.isEmpty) {
-          _switchState(null);
-        } else if (index < _editorStates.length){
-          _switchState(_editorStates[index]);
-        } else {
-          _switchState(_editorStates[index - 1]);
-        }
-      }
-
-      persistState();
-    }
-  }
-
-  void persistState() {
-    var stateData = _editorStates.map((state) => state.toMap()).toList();
-    _prefs.setValue('editorStates', JSON.encode(stateData));
-  }
-
-  _EditorState _getStateFor(File file) {
-    for (_EditorState state in _editorStates) {
-      if (state.file == file) {
-        return state;
-      }
-    }
-
-    return null;
-  }
-
-  void _switchState(_EditorState state) {
-    if (_currentState != state) {
-      _currentState = state;
-      _selectedController.add(currentFile);
-      if (state == null) {
-          _aceEditor.switchTo(null);
-          persistState();
-      } else {
-        state.withSession().then((state) {
-          // Test if other state have been set before this state is appiled.
-          if (state != _currentState) return;
-          _selectedController.add(currentFile);
-          _aceEditor.switchTo(state.session);
-          persistState();
-        });
-      }
-    }
-  }
-
-  Timer _timer;
-
-  void _startSaveTimer() {
-    if (_timer != null) _timer.cancel();
-
-    _timer = new Timer(new Duration(seconds: 2), () => _saveAll());
-  }
-
-  void _saveAll() {
-    if (_timer != null) {
-      _timer.cancel();
-      _timer = null;
-    }
-
-    // TODO: start a workspace change event; this might modify multiple files
-    _editorStates.forEach((e) => e.save());
-    // TODO: end the workspace change event
-  }
-
-  // EditorProvider
-  AceEditor createEditorForFile(Resource file) {
-    openOrSelect(file);
-    return _aceEditor;
-  }
-
-  void selectFileForEditor(AceEditor editor, Resource file) {
-    _EditorState state = _getStateFor(file);
-    _switchState(state);
-  }
+  /// Resize the editor.
+  void resize();
 }
 
-/**
- * This class tracks the state associated with each open editor.
- */
-class _EditorState {
-  EditorManager manager;
-  File file;
-  EditSession session;
+abstract class EditorState {
+  /// File combined with the editor.
+  File get file;
 
-  int scrollTop = 0;
-  bool _dirty = false;
+  /// Deserialize the state of an editor.
+  /// Returns `true` iff success.
+  bool fromMap(Workspace workspace, Map map);
 
-  _EditorState.fromFile(this.manager, this.file);
-
-  factory _EditorState.fromMap(EditorManager manager,
-                               Workspace workspace,
-                               Map m) {
-    File f = workspace.restoreResource(m['file']);
-
-    if (f == null) {
-      return null;
-    } else {
-      _EditorState state = new _EditorState.fromFile(manager, f);
-      state.scrollTop = m['scrollTop'];
-      return state;
-    }
-  }
-
-  bool get dirty => _dirty;
-
-  set dirty(bool value) {
-    if (_dirty != value) {
-      _dirty = value;
-      if (_dirty) {
-        manager._startSaveTimer();
-      }
-    }
-  }
-
-  bool get hasSession => session != null;
-
-  void save() {
-    if (dirty) {
-      file.setContents(session.value);
-      dirty = false;
-    }
-  }
-
-  /**
-   * Return a [Map] representing the persistable state of this editor. This map
-   * can later be passed into [_EditorState.fromMap] to restore the state.
-   */
-  Map toMap() {
-    Map m = {};
-    m['file'] = file.persistToToken();
-    m['scrollTop'] = session == null ? scrollTop : session.scrollTop;
-    return m;
-  }
-
-  Future<_EditorState> withSession() {
-    if (hasSession) {
-      return new Future.value(this);
-    } else {
-      return file.getContents().then((text) {
-        session = manager._aceEditor.createEditSession(text, file.name);
-        session.scrollTop = scrollTop;
-        session.onChange.listen((delta) => dirty = true);
-        return this;
-      });
-    }
-  }
+  /// Serializes the state of an editor.
+  Map toMap();
 }

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -17,7 +17,6 @@ import 'lib/actions.dart';
 import 'lib/analytics.dart' as analytics;
 import 'lib/app.dart';
 import 'lib/editorarea.dart';
-import 'lib/editors.dart';
 import 'lib/utils.dart';
 import 'lib/preferences.dart' as preferences;
 import 'lib/tests.dart';
@@ -63,7 +62,7 @@ class Spark extends Application implements FilesControllerDelegate {
 
   AceEditor editor;
   ws.Workspace workspace;
-  EditorManager editorManager;
+  AceEditorManager editorManager;
   EditorArea editorArea;
   analytics.Tracker tracker = new analytics.NullTracker();
 
@@ -103,7 +102,7 @@ class Spark extends Application implements FilesControllerDelegate {
     workspace = new ws.Workspace(localPrefs);
     editor = new AceEditor(new DivElement());
 
-    editorManager = new EditorManager(workspace, editor, localPrefs);
+    editorManager = new AceEditorManager(workspace, editor, localPrefs);
     editorManager.loaded.then((_) {
       List<ws.Resource> files = editorManager.files.toList();
       editorManager.files.forEach((file) {

--- a/ide/app/test/ace_test.dart
+++ b/ide/app/test/ace_test.dart
@@ -7,6 +7,7 @@ library spark.ace_test;
 import 'dart:async';
 import 'dart:html';
 
+import 'package:ace/ace.dart' show EditSession;
 import 'package:unittest/unittest.dart';
 
 import '../lib/ace.dart';
@@ -22,8 +23,7 @@ main() {
 
 class MockAceEditor implements AceEditor {
   /// The element to put the editor in.
-  final Element parentElement = null;
-
+  final Element rootElement = null;
   MockAceEditor();
 
   EditSession createEditSession(String text, String fileName) {
@@ -33,7 +33,7 @@ class MockAceEditor implements AceEditor {
   void focus() { }
   void resize() { }
   void setTheme(String theme) { }
-  void switchTo(EditSession session) { }
+  AceEditorState state;
   set theme(String value) { }
   String get theme => null;
 }

--- a/ide/app/test/editors_test.dart
+++ b/ide/app/test/editors_test.dart
@@ -10,7 +10,6 @@ import 'package:unittest/unittest.dart';
 import 'ace_test.dart';
 import 'files_mock.dart';
 import '../lib/ace.dart';
-import '../lib/editors.dart';
 import '../lib/preferences.dart';
 import '../lib/workspace.dart';
 
@@ -20,7 +19,7 @@ main() {
       Workspace workspace = new Workspace();
       AceEditor editor = new MockAceEditor();
       PreferenceStore store = new MapPreferencesStore();
-      EditorManager manager = new EditorManager(workspace, editor, store);
+      AceEditorManager manager = new AceEditorManager(workspace, editor, store);
 
       MockFileSystem fs = new MockFileSystem();
 


### PR DESCRIPTION
`EditorManager` is the `EditorProvider` for `AceEditor`. Move it to `ace.dart` and make a minimum abstraction of it to prepare for further changes.
