### PR TITLE
fix double click on folder; speed up app launch

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -197,7 +197,7 @@ class Spark extends Application implements FilesControllerDelegate {
       chrome.ChromeFileEntry entry = result.entry;
 
       if (entry != null) {
-        workspace.link(entry, false).then((file) {
+        workspace.link(entry).then((file) {
           editorArea.selectFile(file, forceOpen: true, switchesTab: true);
           workspace.save();
         });
@@ -212,7 +212,7 @@ class Spark extends Application implements FilesControllerDelegate {
       chrome.ChromeFileEntry entry = result.entry;
 
       if (entry != null) {
-        workspace.link(entry, false).then((file) {
+        workspace.link(entry).then((file) {
           _filesController.selectLastFile();
           workspace.save();
         });
@@ -273,7 +273,7 @@ class Spark extends Application implements FilesControllerDelegate {
 
   // Implementation of FilesControllerDelegate interface.
 
-  void selectInEditor(ws.Resource file, {bool forceOpen: false}) {
+  void selectInEditor(ws.File file, {bool forceOpen: false}) {
     if (forceOpen || editorManager.isFileOpend(file)) {
       editorArea.selectFile(file, forceOpen: forceOpen);
     }

--- a/ide/app/test/workspace_test.dart
+++ b/ide/app/test/workspace_test.dart
@@ -32,7 +32,7 @@ main() {
       var workspace = new Workspace();
       MockFileSystem fs = new MockFileSystem();
       var fileEntry = fs.createFile('test.txt', contents: _FILETEXT);
-      return workspace.link(fileEntry, false).then((Resource resource) {
+      return workspace.link(fileEntry).then((Resource resource) {
         expect(resource.name, fileEntry.name);
         String token = resource.persistToToken();
         var restoredResource = workspace.restoreResource(token);
@@ -53,7 +53,7 @@ main() {
         expect(event.type, ResourceEventType.ADD);
       });
 
-      workspace.link(fileEntry, false).then((resource) {
+      workspace.link(fileEntry).then((resource) {
         expect(resource, isNotNull);
         expect(workspace.getChildren().contains(resource), isTrue);
         expect(workspace.getFiles().contains(resource), isTrue);
@@ -68,7 +68,7 @@ main() {
       var fileEntry = fs.createFile('test.txt');
       var resource;
 
-      workspace.link(fileEntry, false).then((res) {
+      workspace.link(fileEntry).then((res) {
         resource = res;
         expect(resource, isNotNull);
         expect(workspace.getChildren().contains(resource), isTrue);
@@ -97,7 +97,7 @@ main() {
         expect(event.type, ResourceEventType.ADD);
       });
 
-      workspace.link(dirEntry, false).then((project) {
+      workspace.link(dirEntry).then((project) {
         expect(project, isNotNull);
         expect(workspace.getChildren().contains(project), isTrue);
         expect(workspace.getProjects().contains(project), isTrue);
@@ -126,7 +126,7 @@ main() {
         expect(event.type, ResourceEventType.ADD);
       });
 
-      workspace.link(projectDir, false).then((project) {
+      workspace.link(projectDir).then((project) {
         expect(project, isNotNull);
         expect(workspace.getChildren().contains(project), isTrue);
         expect(workspace.getProjects().contains(project), isTrue);


### PR DESCRIPTION
Fix one exception, and make the app load faster.
- fix an issue where double clicking on a folder would throw an exception (trying to open a Folder in an editor)
- change the workspace over to not firing events as it's restoring itself. Instead, clients should wait on `whenAvailable()` and then sync their contents to the workspace.
