### PR TITLE
rename main() methods to defineTests()

### DIFF
--- a/ide/app/test/ace_test.dart
+++ b/ide/app/test/ace_test.dart
@@ -11,7 +11,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/ace.dart';
 
-main() {
+defineTests() {
   group('ace', () {
     // This essentially tests that the ace codebase is available.
     test('is available', () {

--- a/ide/app/test/actions_test.dart
+++ b/ide/app/test/actions_test.dart
@@ -11,7 +11,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/actions.dart';
 
-main() {
+defineTests() {
   group('actions', () {
     test('KeyBinding 1', () {
       KeyBinding binding = new KeyBinding('alt-o');

--- a/ide/app/test/all.dart
+++ b/ide/app/test/all.dart
@@ -33,25 +33,25 @@ import 'zlib_test.dart' as zlib_test;
  * Place all new tests here.
  */
 void defineTests() {
-  ace_test.main();
-  actions_test.main();
-  analytics_test.main();
-  analyzer_test.main();
-  app_test.main();
-  compiler_test.main();
-  editors_test.main();
-  files_test.main();
-  git_object_test.main();
-  git_objectstore_test.main();
-  git_pack_test.main();
-  git_pack_index_test.main();
-  git_test.main();
-  git_utils_test.main();
-  preferences_test.main();
-  sdk_test.main();
-  server_test.main();
-  tcp_test.main();
-  utils_test.main();
-  workspace_test.main();
-  zlib_test.main();
+  ace_test.defineTests();
+  actions_test.defineTests();
+  analytics_test.defineTests();
+  analyzer_test.defineTests();
+  app_test.defineTests();
+  compiler_test.defineTests();
+  editors_test.defineTests();
+  files_test.defineTests();
+  git_object_test.defineTests();
+  git_objectstore_test.defineTests();
+  git_pack_test.defineTests();
+  git_pack_index_test.defineTests();
+  git_test.defineTests();
+  git_utils_test.defineTests();
+  preferences_test.defineTests();
+  sdk_test.defineTests();
+  server_test.defineTests();
+  tcp_test.defineTests();
+  utils_test.defineTests();
+  workspace_test.defineTests();
+  zlib_test.defineTests();
 }

--- a/ide/app/test/analytics_test.dart
+++ b/ide/app/test/analytics_test.dart
@@ -8,7 +8,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/analytics.dart' as analytics;
 
-main() {
+defineTests() {
   group('analytics', () {
     // This essentially tests whether the google-analytics-bundle.js codebase is
     // available.

--- a/ide/app/test/analyzer_test.dart
+++ b/ide/app/test/analyzer_test.dart
@@ -9,7 +9,7 @@ import 'package:unittest/unittest.dart';
 import '../lib/analyzer.dart';
 import '../lib/utils.dart';
 
-main() {
+defineTests() {
   group('analyzer.', () {
     test('ChromeDartSdk exists', () {
       return createSdk().then((ChromeDartSdk sdk) {

--- a/ide/app/test/app_test.dart
+++ b/ide/app/test/app_test.dart
@@ -13,7 +13,7 @@ import '../lib/app.dart';
 // TODO: test that adding a participant after start() has been called, calls
 // the lifecycle methods of that participant.
 
-main() {
+defineTests() {
   group('app', () {
     test('application fires start events', () {
       TestApplication app = new TestApplication();

--- a/ide/app/test/compiler_test.dart
+++ b/ide/app/test/compiler_test.dart
@@ -8,7 +8,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/compiler.dart';
 
-main() {
+defineTests() {
   group('compiler', () {
     Compiler compiler;
 

--- a/ide/app/test/editors_test.dart
+++ b/ide/app/test/editors_test.dart
@@ -14,7 +14,7 @@ import '../lib/editors.dart';
 import '../lib/preferences.dart';
 import '../lib/workspace.dart';
 
-main() {
+defineTests() {
   group('editors', () {
     test('general test', () {
       Workspace workspace = new Workspace();

--- a/ide/app/test/files_test.dart
+++ b/ide/app/test/files_test.dart
@@ -9,7 +9,7 @@ import 'package:unittest/unittest.dart';
 
 import 'files_mock.dart';
 
-main() {
+defineTests() {
   group('files', () {
     test('package directory available', () {
       return chrome_gen.runtime.getPackageDirectoryEntry().then((chrome_gen.DirectoryEntry dir) {

--- a/ide/app/test/git_object_test.dart
+++ b/ide/app/test/git_object_test.dart
@@ -8,7 +8,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/git/git_object.dart';
 
-main() {
+defineTests() {
   group('git.objects', () {
     test('createObject', () {
       String sha = "shastring";

--- a/ide/app/test/git_objectstore_test.dart
+++ b/ide/app/test/git_objectstore_test.dart
@@ -20,7 +20,7 @@ Future getGitDirectory() {
   });
 }
 
-main() {
+defineTests() {
   group('git.objectstore', () {
     test('load', () {
       return getGitDirectory().then((chrome_gen.DirectoryEntry root) {

--- a/ide/app/test/git_pack_index_test.dart
+++ b/ide/app/test/git_pack_index_test.dart
@@ -53,7 +53,7 @@ String shaToString(List<int> sha) {
   return UTF8.decode(sha);
 }
 
-main() {
+defineTests() {
   group('git.packIndex', () {
     test('packIndexParse', () {
       return initPack().then((Pack pack) {

--- a/ide/app/test/git_pack_test.dart
+++ b/ide/app/test/git_pack_test.dart
@@ -15,7 +15,7 @@ final String PACK_FILE_PATH = 'test/data/pack_test.pack';
 final String PACK_INDEX_FILE_PATH = 'test/data/pack-_index_test.idx';
 
 
-main() {
+defineTests() {
   group('git.pack', () {
     test('parsePack', () {
       return chrome_gen.runtime.getPackageDirectoryEntry().then(

--- a/ide/app/test/git_test.dart
+++ b/ide/app/test/git_test.dart
@@ -8,7 +8,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/git/git.dart';
 
-main() {
+defineTests() {
   group('git', () {
     test('is available', () {
       expect(Git.available, true);

--- a/ide/app/test/git_utils_test.dart
+++ b/ide/app/test/git_utils_test.dart
@@ -12,7 +12,7 @@ final String SHA_STRING_TEST = "6a21325b42661e4ae5bc659a1cb66a21938d784f";
 final List<int> SHA_BYTES_TEST =
     [106,33,50,91,66,102,30,74,229,188,101,154,28,182,106,33,147,141,120,79];
 
-main() {
+defineTests() {
   group('git_utils', () {
     test('shaToBytes', () {
       expect(shaToBytes(SHA_STRING_TEST), SHA_BYTES_TEST);

--- a/ide/app/test/preferences_test.dart
+++ b/ide/app/test/preferences_test.dart
@@ -11,7 +11,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/preferences.dart';
 
-main() {
+defineTests() {
   group('preferences.chrome', () {
     test('writeRead', () {
       localStore.setValue("foo1", "bar1");

--- a/ide/app/test/sdk_test.dart
+++ b/ide/app/test/sdk_test.dart
@@ -8,7 +8,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/sdk.dart';
 
-main() {
+defineTests() {
   group('sdk', () {
     DartSdk sdk;
 

--- a/ide/app/test/server_test.dart
+++ b/ide/app/test/server_test.dart
@@ -22,7 +22,7 @@ import '../lib/tcp.dart' as tcp;
 // TODO(devoncarew): test serving a stream response (contentLength == -1)
 
 
-main() {
+defineTests() {
   group('PicoServer', () {
     PicoServer server;
 

--- a/ide/app/test/tcp_test.dart
+++ b/ide/app/test/tcp_test.dart
@@ -18,7 +18,7 @@ class _SocketException extends TypeMatcher {
   bool matches(item, Map matchState) => item is tcp.SocketException;
 }
 
-main() {
+defineTests() {
   EchoServer echoServer = new EchoServer();
 
   group('tcp.TcpClient', () {

--- a/ide/app/test/utils_test.dart
+++ b/ide/app/test/utils_test.dart
@@ -8,7 +8,7 @@ import 'package:unittest/unittest.dart';
 
 import '../lib/utils.dart';
 
-main() {
+defineTests() {
   group('utils', () {
     test('i18n found', () {
       expect(i18n('app_name'), 'Spark');

--- a/ide/app/test/workspace_test.dart
+++ b/ide/app/test/workspace_test.dart
@@ -13,7 +13,7 @@ import '../lib/workspace.dart';
 
 const _FILETEXT = 'This is sample text for mock file entry.';
 
-main() {
+defineTests() {
   group('workspace', () {
 
     test('create file and check contents', () {

--- a/ide/app/test/zlib_test.dart
+++ b/ide/app/test/zlib_test.dart
@@ -16,7 +16,7 @@ final String ZLIB_INPUT_STRING = "This is a test.";
 final String ZLIB_DEFLATE_OUTPUT =
   "12015613194651300821924236481415120184233272346311218722219302251454341151536";
 
-main() {
+defineTests() {
   group('git.zlib', () {
     test('inflate', () {
 


### PR DESCRIPTION
Rename `main()` to `defineTests()`, to reduce the number of entry points that a certain package manager will try and deploy.

@ussuri @dinhviethoa 
