### PR TITLE
Correctly handle the 'active' attribute on spark-button

### DIFF
--- a/ide/app/spark_polymer.html
+++ b/ide/app/spark_polymer.html
@@ -46,7 +46,7 @@
 <body>
   <div id="toolbar">
     <spark-button id="newFile" primary="true">New File</spark-button>
-    <spark-button id="openFile">Open File...</spark-button>
+    <spark-button id="openFile" active="false">Open File...</spark-button>
 
     <span id="status"></span>
   

--- a/widgets/lib/spark-button/spark-button.dart
+++ b/widgets/lib/spark-button/spark-button.dart
@@ -11,10 +11,15 @@ import '../src/widget.dart';
 @CustomTag('spark-button')
 class SparkButton extends Widget {
   @published bool primary = false;
-  @published bool active = false;
+  @published bool active = true;
 
-  @observable String get btnClasses =>
-      joinClasses([CSS_BUTTON, primary ? CSS_PRIMARY : CSS_DEFAULT]);
+  @observable String get btnClasses {
+    return joinClasses([
+      CSS_BUTTON,
+      primary ? CSS_PRIMARY : CSS_DEFAULT,
+      active ? Widget.CSS_ENABLED : Widget.CSS_DISABLED
+    ]);
+  }
 
   static const CSS_BUTTON = "btn";
   static const CSS_DEFAULT = "btn-default";

--- a/widgets/lib/spark-button/spark-button.html
+++ b/widgets/lib/spark-button/spark-button.html
@@ -14,8 +14,6 @@
       }
     </style>
     
-    <!-- Handle "active" properly, possibly using 'template if'.
-         Setting 'disabled' attribute here somehow doesn't work. -->
     <button type="button" class={{btnClasses}}>
       <content></content>
     </button>


### PR DESCRIPTION
TBR: @terrylucas
