### PR TITLE
Highlight only when dropping is possible (fixed #303) and fixed persista...

### DIFF
--- a/ide/app/lib/ui/widgets/listview_delegate.dart
+++ b/ide/app/lib/ui/widgets/listview_delegate.dart
@@ -52,12 +52,12 @@ abstract class ListViewDelegate {
   void listViewDoubleClicked(ListView view, List<int> rowIndexes, Event event);
 
   /**
-   * This method is called on dragenter.
+   * This method is called on dragenter and dragover.
    * Return 'copy', 'move', 'link' or 'none'.
    * It will adjust the visual of the mouse cursor when the item is
    * dragged over the treeview.
    */
-  String listViewDropEffect(ListView view);
+  String listViewDropEffect(ListView view, MouseEvent event);
 
   /**
    * This method is called when the user confirmed dropped an item on the list.
@@ -76,11 +76,11 @@ abstract class ListViewDelegate {
    * This method is called when the mouse cursor enters the list visual area
    * while the user is dragging an item.
    */
-  void listViewDragEnter(ListView view);
+  void listViewDragEnter(ListView view, MouseEvent event);
 
   /**
    * This method is called when the mouse cursor leaves the list visual area
    * while the user is dragging an item.
    */
-  void listViewDragLeave(ListView view);
+  void listViewDragLeave(ListView view, MouseEvent event);
 }

--- a/ide/app/lib/ui/widgets/treeview_cell.dart
+++ b/ide/app/lib/ui/widgets/treeview_cell.dart
@@ -97,8 +97,9 @@ class TreeViewCell implements ListViewCell {
     _embeddedCellContainer.onDragStart.listen((event) {
       _treeView.privateCheckSelectNode(_row.nodeUID);
       // Dragged data.
+      Map dragInfo = {'uuid': _treeView.uuid, 'selection': _treeView.selection};
       event.dataTransfer.setData('application/x-spark-treeview',
-          JSON.encode(_treeView.selection));
+          JSON.encode(dragInfo));
       TreeViewDragImage imageInfo = _treeView.privateDragImage(event);
       if (imageInfo != null) {
         event.dataTransfer.setDragImage(imageInfo.image,

--- a/ide/app/lib/ui/widgets/treeview_delegate.dart
+++ b/ide/app/lib/ui/widgets/treeview_delegate.dart
@@ -62,7 +62,9 @@ abstract class TreeViewDelegate {
    * It will adjust the visual of the mouse cursor when the item is
    * dragged over the treeview.
    */
-  String treeViewDropEffect(TreeView view);
+  String treeViewDropEffect(TreeView view,
+                            DataTransfer dataTransfer,
+                            String nodeUID);
 
   /**
    * This method is called when the dragged item is actually dropped on the
@@ -77,6 +79,30 @@ abstract class TreeViewDelegate {
   void treeViewDropCells(TreeView view,
                          List<String> nodesUIDs,
                          String targetNodeUID);
+
+  /**
+   * This method is called when the user dropped nodes from the treeview to one
+   * of its node.
+   * This method is called with a null destinationNodeUID if the nodes are not
+   * dropped on a specific node.
+   */
+  bool treeViewAllowsDropCells(TreeView view,
+                               List<String> nodesUIDs,
+                               String destinationNodeUID) {
+
+  }
+
+  /**
+   * This method is called when the user dropped an external item to one of its
+   * node.
+   * This method is called with a null destinationNodeUID if the external item
+   * is not not dropped on a specific node.
+   */
+  bool treeViewAllowsDrop(TreeView view,
+                          DataTransfer dataTransfer,
+                          String destinationNodeUID) {
+
+  }
 
   /**
    * This method provides a drag image and location for the given nodes UIDs.

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   spark_widgets:
     path: ../widgets
   unittest: any
+  uuid: any
 dev_dependencies:
   args: any
   grinder: '>=0.4.2'


### PR DESCRIPTION
- Highlight only when dropping is possible (fixed #303)
  Added two delegate methods:
  - treeViewAllowsDropCells()
  - treeViewAllowsDrop()
    Call treeViewDropEffect() more often to update the state.
- Fixed persistant highlight issue (fixed #310)
- Misc:
  Added uuid to the treeview to be able to match it later.
  For now, we're not able to match the treeview all the time because of a bug in drag&drop.
  (We cannot fetch the data on dragOver).

@keertip
