### PR TITLE
pubspec tweaks, in support of moving towards pub build

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -3,6 +3,8 @@ author: Chrome Team <apps-dev@chromium.org>
 version: 0.1.4-dev
 homepage: https://github.com/GoogleChrome/spark
 description: A Chrome app based development environment.
+environment:
+  sdk: ">=1.0.0 <2.0.0"
 dependencies:
   ace: '>=0.1.3'
   analyzer: any
@@ -14,6 +16,7 @@ dependencies:
   intl: any
   logging: any
   mime: any
+  polymer: any
   spark_widgets:
     path: ../widgets
   unittest: any
@@ -21,3 +24,6 @@ dependencies:
 dev_dependencies:
   args: any
   grinder: '>=0.4.3'
+transformers:
+- polymer:
+    entry_points: web/spark_polymer.html


### PR DESCRIPTION
Some pubspec tweaks, in support of us eventually moving towards using `pub build` w/ the polymer version of the app. A few blockers currently are:
- pub can't build from the app/ directory
- dart2js is not available as a real pub package
- pub (or pub and the polymer transformer?) don't preserve the CSP output from dart2js

And not a blocker, but annoying:
- pub insists on building every entrypoint in the web/ folder - there's not way currently to scope your build to a single specified entrypoint

@ussuri 
