### PR TITLE
fix a speed issue w/ the zlib encoder and js interop

### DIFF
--- a/ide/app/lib/utils.dart
+++ b/ide/app/lib/utils.dart
@@ -11,9 +11,7 @@ import 'package:chrome_gen/chrome_app.dart' as chrome;
 /**
  * This method is shorthand for [chrome.i18n.getMessage].
  */
-String i18n(String messageId) {
-  return chrome.i18n.getMessage(messageId);
-}
+String i18n(String messageId) => chrome.i18n.getMessage(messageId);
 
 String capitalize(String s) {
   return s.isEmpty ? '' : (s[0].toUpperCase() + s.substring(1));
@@ -53,6 +51,61 @@ String baseName(String path) {
  * Return whether the current runtime is dart2js (vs Dartium).
  */
 bool isDart2js() => identical(1, 1.0);
+
+/**
+ * A simple class to do `print()` profiling. It is used to profile a single
+ * operation, and can time multiple sequential tasks within that operation.
+ * Each call to [emit] reset the task timer, but does not effect the operation
+ * timer. Call [finish] when the whole operation is complete.
+ */
+class PrintProfiler {
+  final String name;
+  final bool quiet;
+
+  int _previousTaskTime = 0;
+  Stopwatch _stopwatch = new Stopwatch();
+
+  /**
+   * Create a profiler to time a single operation (`name`).
+   */
+  PrintProfiler(this.name, {this.quiet: false}) {
+    _stopwatch.start();
+  }
+
+  /**
+   * The elapsed time for the current task.
+   */
+  int currentElapsedMs() => _stopwatch.elapsedMilliseconds;
+
+  /**
+   * Finish the current task and print out that task's elapsed time.
+   */
+  void emit(String taskName) {
+    _stopwatch.stop();
+    int ms = _stopwatch.elapsedMilliseconds;
+    if (!quiet) {
+      print('${name}, ${taskName} ${ms / 1000}s');
+    }
+    _previousTaskTime += ms;
+    _stopwatch.reset();
+    _stopwatch.start();
+  }
+
+  /**
+   * Stop the timer, and print out the total time for the operation.
+   */
+  void finish() {
+    _stopwatch.stop();
+    if (!quiet) {
+      print('${name} total: ${totalElapsedMs() / 1000}s');
+    }
+  }
+
+  /**
+   * The elapsed time for the whole operation.
+   */
+  int totalElapsedMs() => _previousTaskTime + _stopwatch.elapsedMilliseconds;
+}
 
 /**
  * Returns a minimal textual description of the stack trace. I.e., instead of a

--- a/ide/app/test/git/zlib_test.dart
+++ b/ide/app/test/git/zlib_test.dart
@@ -10,6 +10,7 @@ import 'dart:typed_data';
 import 'package:unittest/unittest.dart';
 import 'package:utf/utf.dart';
 
+import '../../lib/utils.dart';
 import '../../lib/git/zlib.dart';
 
 final String ZLIB_INPUT_STRING = "This is a test.";
@@ -19,25 +20,48 @@ final String ZLIB_DEFLATE_OUTPUT =
 defineTests() {
   group('git.zlib', () {
     test('inflate', () {
-
       // deflate a string.
       Uint8List buffer = new Uint8List.fromList(encodeUtf8(ZLIB_INPUT_STRING));
       ZlibResult deflated = Zlib.deflate(buffer);
-      Uint8List buffer2 = new Uint8List.fromList(deflated.buffer.getBytes());
+      Uint8List buffer2 = new Uint8List.fromList(deflated.data);
 
       // inflate the string back.
       ZlibResult result = Zlib.inflate(buffer2, null);
 
-      String out = UTF8.decode(result.buffer.getBytes());
-      return expect(out, ZLIB_INPUT_STRING);
+      String out = UTF8.decode(result.data);
+      expect(out, ZLIB_INPUT_STRING);
     });
 
     test('deflate', () {
       Uint8List buffer = new Uint8List.fromList(encodeUtf8(ZLIB_INPUT_STRING));
       ZlibResult result = Zlib.deflate(buffer);
 
-      List<int> bytes = result.buffer.getBytes();
-      return expect(bytes.join(''), ZLIB_DEFLATE_OUTPUT);
+      List<int> bytes = result.data;
+      expect(bytes.join(''), ZLIB_DEFLATE_OUTPUT);
+    });
+
+    // This test will time out if zlib deflate is very slow.
+    test('speed test', () {
+      PrintProfiler timer = new PrintProfiler('zlib test', quiet: true);
+
+      StringBuffer buf = new StringBuffer();
+      for (int i = 0; i < 10000; i++) {
+        buf.writeln(ZLIB_INPUT_STRING);
+      }
+
+      timer.emit('create string');
+
+      String str = buf.toString();
+      Uint8List data = new Uint8List.fromList(UTF8.encoder.convert(str));
+      timer.emit('encode');
+      ZlibResult result = Zlib.deflate(data);
+      timer.emit('deflate');
+      result = Zlib.inflate(result.data, null);
+      timer.emit('inflate');
+      String decodedString = UTF8.decoder.convert(result.data);
+      timer.emit('decode');
+      expect(decodedString, str);
+      timer.finish();
     });
   });
 }


### PR DESCRIPTION
Fix a performance issue w/ zlib deflate (fixes https://github.com/dart-lang/spark/issues/295).

Essentially, the array we were deflating was not being converted to a JS array, but a proxy object. So each array access from JS required a JS <--> Dart round trip. Now we convert the array to a JS one before called deflate - the operation is ~60x faster.

@gaurave 
