### PR TITLE
Analytics exceptions

### DIFF
--- a/ide/app/lib/analytics.dart
+++ b/ide/app/lib/analytics.dart
@@ -192,6 +192,10 @@ class Tracker extends _ProxyHolder {
    * may contain personally identifiable information.
    */
   void sendException([String description, bool fatal]) {
+    if (description != null && description.length > MAX_EXCEPTION_LENGTH) {
+      description = '${description.substring(0, MAX_EXCEPTION_LENGTH - 1)}~';
+    }
+
     _proxy.callMethod('sendException', [description, fatal]);
   }
 

--- a/ide/app/lib/utils.dart
+++ b/ide/app/lib/utils.dart
@@ -177,7 +177,7 @@ String _minimizeLine(String line) {
     return '${method} ${location}';
   }
 
-  // Then try a dart2js stack trace.
+  // Try and match a dart2js stack trace.
   match = DART2JS_REGEX_1.firstMatch(line);
 
   if (match != null) {
@@ -186,7 +186,7 @@ String _minimizeLine(String line) {
     return '${method} ${location}';
   }
 
-  // Then try a second dart2js stack trace.
+  // Try and match an alternative dart2js stack trace format.
   match = DART2JS_REGEX_2.firstMatch(line);
 
   if (match != null) {

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -412,10 +412,6 @@ class Spark extends Application implements FilesControllerDelegate {
     String errorDesc = error != null ? error.runtimeType.toString() : '';
     String desc = '${errorDesc}\n${minimizeStackTrace(stackTrace)}'.trim();
 
-    if (desc.length > analytics.MAX_EXCEPTION_LENGTH) {
-      desc = '${desc.substring(0, analytics.MAX_EXCEPTION_LENGTH - 1)}~';
-    }
-
     tracker.sendException(desc);
   }
 }

--- a/ide/app/test/utils_test.dart
+++ b/ide/app/test/utils_test.dart
@@ -38,10 +38,17 @@ defineTests() {
     });
 
     test('dart2js stack trace', () {
-      final line = '  at Object.wrapException (chrome-extension://aadcannocln/spark.dart.precompiled.js:2646:13)';
+      final line = 'at Object.wrapException (chrome-extension://aadcannocln/spark.dart.precompiled.js:2646:13)';
       Match match = DART2JS_REGEX_1.firstMatch(line);
       expect(match.group(1), 'Object.wrapException');
       expect(match.group(2), 'chrome-extension://aadcannocln/spark.dart.precompiled.js:2646:13');
+    });
+
+    test('dart2js stack trace alternative', () {
+      final line = r'at Object.wrapException [as call$0] (chrome-extension://aadcannocln/spark.dart.precompiled.js:2646:13)';
+      Match match = DART2JS_REGEX_2.firstMatch(line);
+      expect(match.group(1), 'Object.wrapException');
+      expect(match.group(3), 'chrome-extension://aadcannocln/spark.dart.precompiled.js:2646:13');
     });
 
     test('minimizeStackTrace', () {


### PR DESCRIPTION
@lukechurch for review

This fixes an issue with parsing dart2js stack traces, and uses [Zones](https://api.dartlang.org/docs/channels/stable/latest/dart_async/Zone.html) to capture uncaught exceptions.

I think polymer might also make use of zones? In which case we may need to re-visit this with the polymer move.
