### PR TITLE
Fixed mouse icon while dragging over items.

### DIFF
--- a/ide/app/lib/ui/files_controller.dart
+++ b/ide/app/lib/ui/files_controller.dart
@@ -157,8 +157,13 @@ class FilesController implements TreeViewDelegate {
                             html.DataTransfer dataTransfer,
                             String nodeUID) {
     if (dataTransfer.types.contains('Files')) {
-      // Import files.
-      return "copy";
+      if (nodeUID == null) {
+        // Importing to top-level is not allowed for now.
+        return "none";
+      } else {
+        // Import files into a folder.
+        return "copy";
+      }
     } else {
       // Move files inside top-level folder.
       return "move";


### PR DESCRIPTION
Don't show a copy mouse icon when dropping is not allowed at this location.

TBR: @keertip 
