### PR TITLE
move the toggle ui action from the context menu to the spark menu

### DIFF
--- a/ide/app/background.js
+++ b/ide/app/background.js
@@ -92,16 +92,16 @@ EditorWindow.prototype.onCreated_ = function(win) {
 
 // A listener called after the DOM has been constructed for the content window.
 EditorWindow.prototype.onLoad_ = function() {
-  chrome.contextMenus.create({
-    title: "Spark: Switch UI",
-    id: 'switch_ui',
-    contexts: [ 'all' ]
-  });
-  chrome.contextMenus.onClicked.addListener(function(info) {
-    if (info.menuItemId == 'switch_ui') {
-      this.app_.switchUi();
-    }
-  }.bind(this));
+//  chrome.contextMenus.create({
+//    title: "Spark: Switch UI",
+//    id: 'switch_ui',
+//    contexts: [ 'all' ]
+//  });
+//  chrome.contextMenus.onClicked.addListener(function(info) {
+//    if (info.menuItemId == 'switch_ui') {
+//      this.app_.switchUi();
+//    }
+//  }.bind(this));
 }
 
 // Destroy the window, if any.

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -249,6 +249,7 @@ class Spark extends Application implements FilesControllerDelegate {
     actionManager.registerAction(new RunTestsAction(this));
     actionManager.registerAction(new AboutSparkAction(
         this, getDialogElement('#aboutDialog')));
+    actionManager.registerAction(new TogglePolymerUIAction(this));
     actionManager.registerKeyListener();
   }
 
@@ -283,6 +284,7 @@ class Spark extends Application implements FilesControllerDelegate {
       ul.children.add(createMenuSeparator());
       ul.children.add(createMenuItem(actionManager.getAction('run-tests')));
       ul.children.add(createMenuItem(actionManager.getAction('git-clone')));
+      ul.children.add(createMenuItem(actionManager.getAction('toggle-polymer')));
     }
 
     ul.children.add(createMenuSeparator());
@@ -853,13 +855,37 @@ class AboutSparkAction extends SparkActionWithDialog {
     _dialog.show();
   }
 
-  void _commit() {
-    // Nothing to do for this dialog.
-  }
+  void _commit() { }
 }
 
 class RunTestsAction extends SparkAction {
-  RunTestsAction(Spark spark) : super(spark, "run-tests", "Run Tests");
+  RunTestsAction(Spark spark): super(spark, "run-tests", "Run Tests");
 
   _invoke([Object context]) => spark._testDriver.runTests();
+}
+
+/**
+ * Toggle between the spark.html and spark_polymer.html UIs.
+ */
+class TogglePolymerUIAction extends SparkAction {
+  static final List SKINS = ["spark.html", "spark_polymer.html"];
+
+  TogglePolymerUIAction(Spark spark):
+    super(spark, "toggle-polymer", "Toggle Polymer UI");
+
+  void _invoke([Object context]) {
+    chrome.storage.local.get('skin').then((Map m) {
+      String curVal = m == null ? SKINS[0] : m['skin'];
+      int index = (SKINS.indexOf(curVal) + 1) % SKINS.length;
+      String newVal = SKINS[index];
+
+      chrome.storage.local.set({'skin': newVal}).then((_) {
+        var options = new chrome.CreateWindowOptions(
+            id: 'main_editor_window${newVal}');
+        chrome.app.window.create(newVal, options).then((_) {
+          chrome.app.window.current().close();
+        });
+      });
+    });
+  }
 }

--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -105,6 +105,7 @@ class SparkPolymer extends Spark {
       ul.children.add(createMenuSeparator());
       ul.children.add(createMenuItem(actionManager.getAction('run-tests')));
       ul.children.add(createMenuItem(actionManager.getAction('git-clone')));
+      ul.children.add(createMenuItem(actionManager.getAction('toggle-polymer')));
     }
 
     ul.children.add(createMenuSeparator());


### PR DESCRIPTION
@ussuri, this changes where we contribute the 'switch UI' menu item, from the browser's context menu to the Spark menu. It partially addresses https://github.com/dart-lang/spark/issues/384.
