### PR TITLE
upgrade to path 1.0.0

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   intl: any
   logging: any
   mime: any
-  path: any
   polymer: any
   polymer_elements:
     git: https://github.com/ErikGrimes/polymer_elements
@@ -25,7 +24,7 @@ dependencies:
   unittest: any
   uuid: any
 dependency_overrides:
-  path: '1.0.0-rc.1'
+  path: '>=1.0.0'
 dev_dependencies:
   args: any
   grinder: '>=0.4.3'

--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -249,6 +249,8 @@ void _dart2jsCompile(GrinderContext context, Directory target, String filePath,
   runSdkBinary(context, 'dart2js', arguments: [
      joinDir(target, [filePath]).path,
      '--package-root=packages',
+     '--suppress-warnings',
+     '--suppress-hints',
      '--out=' + joinDir(target, ['${filePath}.js']).path]);
 
   // clean up unnecessary (and large) files


### PR DESCRIPTION
@gaurave 

A tiny CL to move to the latest version of `path`, and add back in the warning suppression code to dart2js compiles.
