### PR TITLE
Keep collapsed/expanded state of the files view

### DIFF
--- a/ide/app/lib/ui/files_controller.dart
+++ b/ide/app/lib/ui/files_controller.dart
@@ -7,6 +7,7 @@
  */
 library spark.ui.widgets.files_controller;
 
+import 'dart:convert' show JSON;
 import 'dart:html' as html;
 
 import 'package:bootjack/bootjack.dart' as bootjack;
@@ -18,6 +19,7 @@ import 'widgets/listview_cell.dart';
 import 'widgets/treeview.dart';
 import 'widgets/treeview_delegate.dart';
 import '../actions.dart';
+import '../preferences.dart' as preferences;
 import '../workspace.dart';
 
 class FilesController implements TreeViewDelegate {
@@ -26,6 +28,7 @@ class FilesController implements TreeViewDelegate {
   List<Resource> _files;
   FilesControllerDelegate _delegate;
   Map<String, Resource> _filesMap;
+  preferences.PreferenceStore localPrefs = preferences.localStore;
 
   FilesController(Workspace workspace,
                   FilesControllerDelegate delegate,
@@ -418,13 +421,23 @@ class FilesController implements TreeViewDelegate {
         y + counterTextPosition);
   }
 
+  void treeViewSaveExpandedState(TreeView view) {
+    localPrefs.setValue('FilesExpandedState',
+        JSON.encode(_treeView.expandedState));
+  }
+
   void _addAllFiles() {
     for (Resource resource in _workspace.getChildren()) {
       _files.add(resource);
       _recursiveAddResource(resource);
     }
-
-    _treeView.reloadData();
+    localPrefs.getValue('FilesExpandedState').then((String state) {
+      if (state != null) {
+        _treeView.restoreExpandedState(JSON.decode(state));
+      } else {
+        _treeView.reloadData();
+      }
+    });
   }
 
   /**

--- a/ide/app/lib/ui/widgets/listview_delegate.dart
+++ b/ide/app/lib/ui/widgets/listview_delegate.dart
@@ -42,14 +42,15 @@ abstract class ListViewDelegate {
    */
   void listViewSelectedChanged(ListView view,
                                List<int> rowIndexes,
-                               Event event);
+                               Event event) {}
 
   /**
    * The implementation of this method will be run when the cell at the given
    * index `rowIndex` is double-clicked.
    * `view` is the list the callback is called from.
    */
-  void listViewDoubleClicked(ListView view, List<int> rowIndexes, Event event);
+  void listViewDoubleClicked(ListView view, List<int> rowIndexes, Event event) {
+  }
 
   /**
    * This method is called on dragenter and dragover.
@@ -57,30 +58,30 @@ abstract class ListViewDelegate {
    * It will adjust the visual of the mouse cursor when the item is
    * dragged over the treeview.
    */
-  String listViewDropEffect(ListView view, MouseEvent event);
+  String listViewDropEffect(ListView view, MouseEvent event) => null;
 
   /**
    * This method is called when the user confirmed dropped an item on the list.
    * rowIndex is the location where it's been dropped. The value is -1
    * if it's not been dropped on a specific cell.
    */
-  void listViewDrop(ListView view, int rowIndex, DataTransfer dataTransfer);
+  void listViewDrop(ListView view, int rowIndex, DataTransfer dataTransfer) {}
 
   /**
    * This method is called regularly when the user is dragging an item over
    * the list.
    */
-  void listViewDragOver(ListView view, MouseEvent event);
+  void listViewDragOver(ListView view, MouseEvent event) {}
 
   /**
    * This method is called when the mouse cursor enters the list visual area
    * while the user is dragging an item.
    */
-  void listViewDragEnter(ListView view, MouseEvent event);
+  void listViewDragEnter(ListView view, MouseEvent event) {}
 
   /**
    * This method is called when the mouse cursor leaves the list visual area
    * while the user is dragging an item.
    */
-  void listViewDragLeave(ListView view, MouseEvent event);
+  void listViewDragLeave(ListView view, MouseEvent event) {}
 }

--- a/ide/app/lib/ui/widgets/treeview.dart
+++ b/ide/app/lib/ui/widgets/treeview.dart
@@ -153,6 +153,29 @@ class TreeView implements ListViewDelegate {
     return _rowsMap[nodeUID] == null ? false : _rowsMap[nodeUID].expanded;
   }
 
+  List<String> get expandedState {
+    List<String> result = [];
+    if (_rows != null) {
+      // Save expanded state.
+      _rows.forEach((TreeViewRow row) {
+        if (row.expanded) {
+          result.add(row.nodeUID);
+        }
+      });
+    }
+    return result;
+  }
+
+  void restoreExpandedState(List<String> expandedState) {
+    // Save expanded state.
+    _expandedState = new HashSet();
+    _expandedState.addAll(expandedState);
+
+    _fillRows();
+    _expandedState.clear();
+    _listView.reloadData();
+  }
+
   /**
    * Sets expanded state of a node.
    */
@@ -176,6 +199,8 @@ class TreeView implements ListViewDelegate {
           _rowIndexesToNodeUIDs(_listView.selection),
           null);
     }
+
+    _delegate.treeViewSaveExpandedState(this);
   }
 
   void toggleNodeExpanded(String nodeUID) {

--- a/ide/app/lib/ui/widgets/treeview.dart
+++ b/ide/app/lib/ui/widgets/treeview.dart
@@ -42,7 +42,7 @@ class TreeView implements ListViewDelegate {
   // Map from node UID to info.
   Map<String, TreeViewRow> _rowsMap;
   // Saved expanded state of the nodes when reloading the content of the tree.
-  HashSet<String> _expandedState;
+  Set<String> _expandedState;
   // When dragging over a cell the tree view, it's the highlighted cell.
   TreeViewCell _currentDragOverCell;
   // Whether the user can drag a cell.
@@ -123,14 +123,9 @@ class TreeView implements ListViewDelegate {
     _listView.selection = [];
 
     // Save expanded state.
-    _expandedState = new HashSet();
+    _expandedState = new Set();
     if (_rows != null) {
-      // Save expanded state.
-      _rows.forEach((TreeViewRow row) {
-        if (row.expanded) {
-          _expandedState.add(row.nodeUID);
-        }
-      });
+      _expandedState = new Set.from(expandedState);
     }
 
     _fillRows();
@@ -154,23 +149,16 @@ class TreeView implements ListViewDelegate {
   }
 
   List<String> get expandedState {
-    List<String> result = [];
-    if (_rows != null) {
-      // Save expanded state.
-      _rows.forEach((TreeViewRow row) {
-        if (row.expanded) {
-          result.add(row.nodeUID);
-        }
-      });
+    if (_rows == null) {
+      return [];
+    } else {
+      return _rows.where((row) => row.expanded).map((row) => row.nodeUID).
+          toList();
     }
-    return result;
   }
 
   void restoreExpandedState(List<String> expandedState) {
-    // Save expanded state.
-    _expandedState = new HashSet();
-    _expandedState.addAll(expandedState);
-
+    _expandedState = new Set.from(expandedState);
     _fillRows();
     _expandedState.clear();
     _listView.reloadData();

--- a/ide/app/lib/ui/widgets/treeview_delegate.dart
+++ b/ide/app/lib/ui/widgets/treeview_delegate.dart
@@ -47,14 +47,14 @@ abstract class TreeViewDelegate {
    */
   void treeViewSelectedChanged(TreeView view,
                                List<String> nodeUIDs,
-                               Event event);
+                               Event event) {}
 
   /**
    * This method will be called when the give node is double-clicked.
    */
   void treeViewDoubleClicked(TreeView view,
                              List<String> nodeUIDs,
-                             Event event);
+                             Event event) {}
 
   /**
    * This method is called on dragenter.
@@ -64,13 +64,13 @@ abstract class TreeViewDelegate {
    */
   String treeViewDropEffect(TreeView view,
                             DataTransfer dataTransfer,
-                            String nodeUID);
+                            String nodeUID) => null;
 
   /**
    * This method is called when the dragged item is actually dropped on the
    * tree or on a specific node in the treeview.
    */
-  void treeViewDrop(TreeView view, String nodeUID, DataTransfer dataTransfer);
+  void treeViewDrop(TreeView view, String nodeUID, DataTransfer dataTransfer) {}
 
   /**
    * This method is called when a selection of the TreeView is actually dropped
@@ -78,7 +78,7 @@ abstract class TreeViewDelegate {
    */
   void treeViewDropCells(TreeView view,
                          List<String> nodesUIDs,
-                         String targetNodeUID);
+                         String targetNodeUID) {}
 
   /**
    * This method is called when the user dropped nodes from the treeview to one
@@ -88,9 +88,7 @@ abstract class TreeViewDelegate {
    */
   bool treeViewAllowsDropCells(TreeView view,
                                List<String> nodesUIDs,
-                               String destinationNodeUID) {
-
-  }
+                               String destinationNodeUID) {}
 
   /**
    * This method is called when the user dropped an external item to one of its
@@ -100,14 +98,18 @@ abstract class TreeViewDelegate {
    */
   bool treeViewAllowsDrop(TreeView view,
                           DataTransfer dataTransfer,
-                          String destinationNodeUID) {
-
-  }
+                          String destinationNodeUID) {}
 
   /**
    * This method provides a drag image and location for the given nodes UIDs.
    */
   TreeViewDragImage treeViewDragImage(TreeView view,
                                       List<String> nodesUIDs,
-                                      MouseEvent event);
+                                      MouseEvent event) => null;
+
+  /**
+   * This method is called whenever it's a good time to save the state of the
+   * tree.
+   */
+  void treeViewSaveExpandedState(TreeView view) {}
 }


### PR DESCRIPTION
Made some delegate methods optional in TreeViewDelegate and ListViewDelegate.
Fixed #402: Keep expanded/collapsed state of tree nodes.

@keertip @devoncarew 
