### PR TITLE
remove Spark singleton

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -33,9 +33,11 @@ import 'lib/utils.dart';
 import 'lib/workspace.dart' as ws;
 import 'test/all.dart' as all_tests;
 
+analytics.Tracker _analyticsTracker = new analytics.NullTracker();
+
 void main() {
-  createSparkZone().runGuarded(() {
-    isTestMode().then((testMode) {
+  isTestMode().then((testMode) {
+    createSparkZone().runGuarded(() {
       Spark spark = new Spark(testMode);
       spark.start();
     });
@@ -68,19 +70,17 @@ Future<bool> isTestMode() {
  */
 Zone createSparkZone() {
   var errorHandler = (self, parent, zone, error, stackTrace) {
-    Spark.SPARK_SINGLETON._handleUncaughtException(error, stackTrace);
+    _handleUncaughtException(error, stackTrace);
   };
   var specification = new ZoneSpecification(handleUncaughtError: errorHandler);
   return Zone.current.fork(specification: specification);
 }
 
 class Spark extends Application implements FilesControllerDelegate {
-  static Spark SPARK_SINGLETON;
-
-  final bool developerMode;
-
   /// The Google Analytics app ID for Spark.
   static final _ANALYTICS_ID = 'UA-45578231-1';
+
+  final bool developerMode;
 
   AceContainer aceContainer;
   ThemeManager aceThemeManager;
@@ -88,7 +88,6 @@ class Spark extends Application implements FilesControllerDelegate {
   ws.Workspace workspace;
   EditorManager editorManager;
   EditorArea editorArea;
-  analytics.Tracker tracker = new analytics.NullTracker();
 
   preferences.PreferenceStore localPrefs;
   preferences.PreferenceStore syncPrefs;
@@ -101,10 +100,6 @@ class Spark extends Application implements FilesControllerDelegate {
   TestDriver _testDriver;
 
   Spark(this.developerMode) {
-    if (SPARK_SINGLETON == null) {
-      SPARK_SINGLETON = this;
-    }
-
     document.title = appName;
 
     localPrefs = preferences.localStore;
@@ -169,9 +164,15 @@ class Spark extends Application implements FilesControllerDelegate {
   void initAnalytics() {
     analytics.getService('Spark').then((service) {
       // Init the analytics tracker and send a page view for the main page.
-      tracker = service.getTracker(_ANALYTICS_ID);
-      tracker.sendAppView('main');
-      _trackLoggedExceptions();
+      _analyticsTracker = service.getTracker(_ANALYTICS_ID);
+      _analyticsTracker.sendAppView('main');
+
+      // Track logged exceptions.
+      Logger.root.onRecord.listen((LogRecord r) {
+        if (r.level >= Level.SEVERE && r.loggerName != 'spark.tests') {
+          _handleUncaughtException(r.error, r.stackTrace);
+        }
+      });
     });
   }
 
@@ -409,25 +410,6 @@ class Spark extends Application implements FilesControllerDelegate {
   //
   // - End implementation of FilesControllerDelegate interface.
   //
-
-  /**
-   * Handle logged exceptions.
-   */
-  void _trackLoggedExceptions() {
-    Logger.root.onRecord.listen((LogRecord r) {
-      if (r.level >= Level.SEVERE && r.loggerName != 'spark.tests') {
-        _handleUncaughtException(r.error, r.stackTrace);
-      }
-    });
-  }
-
-  void _handleUncaughtException(error, StackTrace stackTrace) {
-    // We don't log the error object itself because of PII concerns.
-    String errorDesc = error != null ? error.runtimeType.toString() : '';
-    String desc = '${errorDesc}\n${minimizeStackTrace(stackTrace)}'.trim();
-
-    tracker.sendException(desc);
-  }
 }
 
 class PlatformInfo {
@@ -576,7 +558,7 @@ abstract class SparkAction extends Action {
 
   void invoke([Object context]) {
     // Send an action event with the 'main' event category.
-    spark.tracker.sendEvent('main', id);
+    _analyticsTracker.sendEvent('main', id);
 
     _invoke(context);
   }
@@ -940,12 +922,8 @@ class AboutSparkAction extends SparkActionWithDialog {
   void _invoke([Object context]) {
     if (isPolymer || !_initialized) {
       var checkbox = getElement('#analyticsCheck');
-      checkbox.checked =
-          spark.tracker.service.getConfig().isTrackingPermitted();
-      checkbox.onChange.listen((e) {
-        spark.tracker.service.getConfig()
-            .setTrackingPermitted(checkbox.checked);
-      });
+      checkbox.checked = _isTrackingPermitted;
+      checkbox.onChange.listen((e) => _isTrackingPermitted = checkbox.checked);
 
       getElement('#aboutVersion').text = spark.appVersion;
 
@@ -965,3 +943,19 @@ class RunTestsAction extends SparkAction {
 
   _invoke([Object context]) => spark._testDriver.runTests();
 }
+
+// analytics code
+
+void _handleUncaughtException(error, StackTrace stackTrace) {
+  // We don't log the error object itself because of PII concerns.
+  String errorDesc = error != null ? error.runtimeType.toString() : '';
+  String desc = '${errorDesc}\n${minimizeStackTrace(stackTrace)}'.trim();
+
+  _analyticsTracker.sendException(desc);
+}
+
+bool get _isTrackingPermitted =>
+    _analyticsTracker.service.getConfig().isTrackingPermitted();
+
+set _isTrackingPermitted(bool value) =>
+    _analyticsTracker.service.getConfig().setTrackingPermitted(value);


### PR DESCRIPTION
@ussuri 

Remove the singleton for the Spark app. It was only being used to access the analytics `tracker` instance - this has been moved to a top-level private variable. Also, some misc cleanup for the analytics code.
