### PR TITLE
when a tab is activated, focus the editing area

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -28,6 +28,8 @@ class AceEditor extends Editor {
   AceEditor(this.aceContainer);
 
   void resize() => aceContainer.resize();
+
+  void focus() => aceContainer.focus();
 }
 
 /**

--- a/ide/app/lib/editorarea.dart
+++ b/ide/app/lib/editorarea.dart
@@ -18,6 +18,7 @@ import 'workspace.dart';
 /// A tab associated with a file.
 abstract class EditorTab extends Tab {
   final Resource file;
+
   EditorTab(EditorArea parent, this.file) : super(parent) {
     label = file.name;
   }
@@ -29,6 +30,7 @@ abstract class EditorTab extends Tab {
 class AceEditorTab extends EditorTab {
   final Editor editor;
   final EditorProvider provider;
+
   AceEditorTab(EditorArea parent, this.provider, this.editor, Resource file)
     : super(parent, file) {
     page = editor.element;
@@ -36,6 +38,7 @@ class AceEditorTab extends EditorTab {
 
   void activate() {
     provider.selectFileForEditor(editor, file);
+    editor.focus();
     super.activate();
   }
 

--- a/ide/app/lib/editors.dart
+++ b/ide/app/lib/editors.dart
@@ -38,6 +38,7 @@ abstract class Editor {
   html.Element get element;
   File get file;
   void resize();
+  void focus();
 }
 
 /**

--- a/ide/app/test/ace_test.dart
+++ b/ide/app/test/ace_test.dart
@@ -54,6 +54,8 @@ class MockAceEditor implements AceEditor {
   Element get element => aceContainer.parentElement;
 
   void resize() { }
+
+  void focus() { }
 }
 
 class MockEditSession implements EditSession {


### PR DESCRIPTION
@keertip This CL focus Ace when a tab is selected. It allows the user to start typing right away in new files or when switching between files.
