### PR TITLE
Open new tab

### DIFF
--- a/ide/app/lib/editorarea.dart
+++ b/ide/app/lib/editorarea.dart
@@ -125,7 +125,7 @@ class EditorArea extends TabView {
   void selectFile(Resource file,
                 {bool forceOpen: false, bool switchesTab: true,
                  bool replaceCurrent: true}) {
-    if (_tabOfFile.containsKey(file) && !forceOpen) {
+    if (_tabOfFile.containsKey(file)) {
       _filenameLabel.text = file.name;
       EditorTab tab = _tabOfFile[file];
       if (switchesTab) tab.select();
@@ -149,6 +149,8 @@ class EditorArea extends TabView {
       }
     }
   }
+  
+  bool isOpenInEditor(Resource file) => _tabOfFile.keys.contains(file);
 
   /// Closes the tab.
   void closeFile(Resource file) {

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -687,7 +687,10 @@ class FileOpenInTabAction extends SparkAction implements ContextAction {
 
   String get category => 'tab';
 
-  bool appliesTo(Object object) => _isFileList(object);
+  // Open in new tab should only appear if the file is not already open
+  // in one of the editor tabs
+  bool appliesTo(Object object) => _isFileList(object) 
+                                && (object as List).every((f) => !spark.editorArea.isOpenInEditor(f));
 }
 
 class FileNewAction extends SparkActionWithDialog implements ContextAction {


### PR DESCRIPTION
If forceOpen is true, then a new tab should always be opened, even
if the file is currently selected in the editor

Fix for [this issue](https://github.com/dart-lang/spark/issues/439)
