### PR TITLE
change to use a hosted dep on polymer_elements

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -17,8 +17,7 @@ dependencies:
   logging: any
   mime: any
   polymer: '>=0.9.0 <0.10.0'
-  polymer_elements:
-    git: https://github.com/ErikGrimes/polymer_elements
+  polymer_elements: any
   spark_widgets:
     path: ../widgets
   unittest: any

--- a/widgets/pubspec.yaml
+++ b/widgets/pubspec.yaml
@@ -7,5 +7,4 @@ environment:
   sdk: ">=1.0.0 <2.0.0"
 dependencies:
   polymer: ">=0.9.0 <0.10.0"
-  polymer_elements:
-    git: https://github.com/ErikGrimes/polymer_elements
+  polymer_elements: any


### PR DESCRIPTION
@ussuri @terrylucas 

This converts our polymer_elements dependency from git to hosted. It looks like `polymer_ui_elements` has been changed to depend on it in a hosted manner, we depend on it using a git dep, and pub doesn't like the two different types of deps used. I don't see direct usage of polymer_ui_elements, but perhaps polymer_elements depends on it?

```
[~/projects/spark/ide] pub install
Resolving dependencies..........
Incompatible dependencies on 'polymer_elements':
 - 'polymer_ui_elements' depends on it from source hosted
 - 'spark' depends on it from source git
```

I tried removing the reference entirely from the pubspec files, but it looks like the polymer_elements library is still used by the polymer version. This CL does fix the build, but the polymer version of the app no longer starts up. @ussuri if you want to investigate a better fix, sgtm.
