### PR TITLE
Locked range of Polymer version

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   intl: any
   logging: any
   mime: any
-  polymer: any
+  polymer: '>=0.9.2'
   spark_widgets:
     path: ../widgets
   unittest: any

--- a/widgets/pubspec.yaml
+++ b/widgets/pubspec.yaml
@@ -4,6 +4,6 @@ author: Chrome Team <apps-dev@chromium.org>
 description: GUI widget library for Spark IDE and applications built with it.
 homepage: https://github.com/GoogleChrome/spark
 environment:
-  sdk: ">=1.0.0 <2.0.0"
+  sdk: '>=1.0.0 <2.0.0'
 dependencies:
-  polymer: any
+  polymer: '>=0.9.2'


### PR DESCRIPTION
Couldn't get pub to download 0.9.2+4 for ide/ with 'polymer: any', even though it did so for widgets/.

TBR: @devoncarew
