### PR TITLE
Open in new tab changes

### DIFF
--- a/ide/app/lib/editorarea.dart
+++ b/ide/app/lib/editorarea.dart
@@ -79,6 +79,8 @@ class EditorArea extends TabView {
     this.allowsLabelBar = allowsLabelBar;
     showLabelBar = false;
   }
+  
+  bool isOpenInTab(Resource file) => _tabOfFile.keys.contains(file);
 
   set showLabelBar(bool showLabelBar) {
     super.showLabelBar = showLabelBar;

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -695,7 +695,8 @@ class FileOpenInTabAction extends SparkAction implements ContextAction {
 
   String get category => 'tab';
 
-  bool appliesTo(Object object) => _isFileList(object);
+  bool appliesTo(Object object) => 
+      _isFileList(object) && (object as List).any((f) => !spark.editorArea.isOpenInTab(f));
 }
 
 class FileNewAction extends SparkActionWithDialog implements ContextAction {


### PR DESCRIPTION
Context menu item "Open In New Tab" is only displayed when the
selected file (or files) are not already open in a new tab.

Fix for issue #439
