### PR TITLE
Fixed the crash on initializing "#renameDialog" in Polymer UI

### DIFF
--- a/ide/app/lib/polymer_ui/spark_polymer_ui.html
+++ b/ide/app/lib/polymer_ui/spark_polymer_ui.html
@@ -298,7 +298,7 @@
     <spark-overlay id="fileNewDialog" class="spark-overlay-scale-slideup">
       <div class="modal-body">
         <p>
-          File name:  <input id="fileName" type="text" focused>
+          File name: <input id="fileNewName" type="text" focused>
         </p>
       </div>
       <div class="modal-footer">
@@ -313,17 +313,17 @@
     </spark-overlay>
 
     <!-- New Folder dialog -->
-    <spark-overlay id="folderNewDialog" class="modal fade">
+    <spark-overlay id="folderNewDialog" class="spark-overlay-scale-slideup">
       <div class="modal-body">
         <p>
           Folder name: <input id="folderName" type="text" focused>
         </p>
       </div>
       <div class="modal-footer">
-        <spark-button class="btn btn-default" data-dismiss="modal">
+        <spark-button data-dismiss="modal">
           Cancel
         </spark-button>
-        <spark-button id="folderNewOkButton" primary class="btn btn-primary"
+        <spark-button id="folderNewOkButton" primary
             data-dismiss="modal">Create</spark-button>
       </div>
     </spark-overlay>
@@ -332,7 +332,7 @@
     <spark-overlay id="renameDialog" class="spark-overlay-scale-slideup">
       <div class="modal-body">
         <p>
-          File name: <input id="fileName" type="text" focused>
+          File name: <input id="renameFileName" type="text" focused>
         </p>
       </div>
       <div class="modal-footer">

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -705,7 +705,7 @@ class FileNewAction extends SparkActionWithDialog implements ContextAction {
   FileNewAction(Spark spark, Element dialog)
       : super(spark, "file-new", "New File…", dialog) {
     defaultBinding("ctrl-n");
-    _nameElement = _triggerOnReturn("#fileName");
+    _nameElement = _triggerOnReturn("#fileNewName");
   }
 
   void _invoke([List<ws.Folder> folders]) {
@@ -846,7 +846,7 @@ class FileRenameAction extends SparkActionWithDialog implements ContextAction {
 
   FileRenameAction(Spark spark, Element dialog)
       : super(spark, "file-rename", "Rename…", dialog) {
-    _nameElement = _triggerOnReturn("#fileName");
+    _nameElement = _triggerOnReturn("#renameFileName");
   }
 
   void _invoke([List<ws.Resource> resources]) {

--- a/ide/app/spark.html
+++ b/ide/app/spark.html
@@ -103,7 +103,7 @@
       <div class="modal-content">
         <div class="modal-body">
           <p>
-            File name: <input id="fileName" focused type="text">
+            File name: <input id="fileNewName" focused type="text">
           </p>
         </div>
         <div class="modal-footer">
@@ -139,7 +139,7 @@
       <div class="modal-content">
         <div class="modal-body">
           <p>
-            File name: <input id="fileName" focused type="text">
+            File name: <input id="renameFileName" focused type="text">
           </p>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
The reason was: Polymer didn't like identical element IDs for the file name input control ("#fileName") under two different dialogs, "#fileNewDialog" and "#renameDialog". dialog.querySelector("#fileName") returned the correct element for the former, but null for the latter. The same worked fine in non-Polymer version.

TBR: @keertip 
