### PR TITLE
Add error message for grind script

### DIFF
--- a/ide/grind
+++ b/ide/grind
@@ -3,4 +3,14 @@
 # All rights reserved. Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+DART_VER=$(dart --version 2>&1)
+if [[ "$DART_VER" != Dart\ VM\ version:* ]] ; then
+  echo "Error: Unable to execute 'dart'"
+  echo "       Please set the DART_SDK environment variable to the SDK path."
+  echo "       And add DART_SDK/bin to PATH environment variable."
+  echo "       e.g.: 'export DART_SDK=your/path/to/dart/dart-sdk'";
+  echo "             'export PATH=\$PATH:\$DART_SDK/bin'";
+  exit -1
+fi
+
 dart tool/grind.dart $@


### PR DESCRIPTION
Is this error message too long? T.T

review @devoncarew 

TEST=./grind  without setting DART_SDK, and DART_SDK/bin

RESULT=

sungguk@sungguk-R570-U-AFLGL:~/program_store/spark/ide$ ./grind 
Error: Unable to execute 'dart'
       Please set the DART_SDK environment variable to the SDK path.
       And add DART_SDK/bin to PATH environment variable.
       e.g.: 'export DART_SDK=your/path/to/dart/dart-sdk'
              'export PATH=$PATH:$DART_SDK/bin'

sungguk@sungguk-R570-U-AFLGL:~/program_store/spark/ide$ 
