### PR TITLE
Fix spark-splitter

### DIFF
--- a/widgets/lib/spark-splitter/spark-splitter.dart
+++ b/widgets/lib/spark-splitter/spark-splitter.dart
@@ -51,7 +51,6 @@ class SparkSplitter extends Widget {
   /// Triggered when the control is first displayed.
   @override
   void enteredView() {
-    print("HERE");
     // TODO(sergeygs): Perhaps switch to using onDrag* instead of onMouse* once
     // support for drag-and-drop in shadow DOM is fixed. It is less important
     // here, because the element is not actually supposed to be dropped onto


### PR DESCRIPTION
Some recent change in Polymer has changed the way custom elements get registered. As a result of that, and possibly some wrong Polymer usage in Spark, all Xyz.created ctors for Spark widgets were called twice. Calling real initialization from there for SparkSplitter caused a crash on the second call, because _target would be initialized to null for some reason. Redone to use enteredView(), which is probably more correct anyway.

TBR: @terrylucas
