### PR TITLE
fix an issue with focus and active editors

### DIFF
--- a/ide/app/lib/editorarea.dart
+++ b/ide/app/lib/editorarea.dart
@@ -38,9 +38,10 @@ class AceEditorTab extends EditorTab {
 
   void activate() {
     provider.selectFileForEditor(editor, file);
-    editor.focus();
     super.activate();
   }
+
+  void focus() => editor.focus();
 
   void resize() => editor.resize();
 }
@@ -126,18 +127,19 @@ class EditorArea extends TabView {
   /// [selectFile] will be called instead. Otherwise the editor provide is
   /// requested to switch the file to the editor in case the editor is shared.
   void selectFile(Resource file,
-                {bool forceOpen: false, bool switchesTab: true,
-                 bool replaceCurrent: true}) {
+                  {bool forceOpen: false, bool switchesTab: true,
+                  bool replaceCurrent: true, bool forceFocus: false}) {
     if (_tabOfFile.containsKey(file)) {
       _filenameLabel.text = file.name;
       EditorTab tab = _tabOfFile[file];
-      if (switchesTab) tab.select();
+      if (switchesTab) tab.select(forceFocus: forceFocus);
       return;
     }
 
     if (forceOpen || replaceCurrent) {
       EditorTab tab;
       _filenameLabel.text = file.name;
+
       if (_imageFileType.hasMatch(file.name)) {
         ImageViewer viewer = new ImageViewer(file);
         tab = new ImageViewerTab(this, viewer, file);
@@ -145,11 +147,14 @@ class EditorArea extends TabView {
         Editor editor = editorProvider.createEditorForFile(file);
         tab = new AceEditorTab(this, editorProvider, editor, file);
       }
+
       if (replaceCurrent) {
         replace(selectedTab, tab, switchesTab: switchesTab);
       } else {
         add(tab, switchesTab: switchesTab);
       }
+
+      if (forceFocus) tab.select(forceFocus: forceFocus);
     }
   }
 

--- a/ide/app/lib/ui/widgets/tabview.dart
+++ b/ide/app/lib/ui/widgets/tabview.dart
@@ -27,7 +27,7 @@ class Tab {
   Tab(this.tabView, {Element page: null, bool closable: true}) {
     _label = new DivElement()..classes.add('tabview-tablabel');
     _label.onClick.listen((e) {
-      select();
+      select(forceFocus: true);
       e.stopPropagation();
       e.preventDefault();
     });
@@ -90,7 +90,13 @@ class Tab {
     tabView.scrollIntoView(this);
   }
 
-  select() => tabView.selectedTab = this;
+  void select({bool forceFocus}) {
+    tabView.selectedTab = this;
+
+    if (forceFocus) focus();
+  }
+
+  void focus() => _pageContainer.focus();
 
   bool close() => tabView.remove(this);
 
@@ -107,6 +113,7 @@ class Tab {
 
 class TabView {
   static const int SCROLL_MARGIN = 7;
+
   final Element parentElement;
   DivElement _tabViewContainer;
   DivElement _tabBar;

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -228,7 +228,7 @@ class Spark extends Application implements FilesControllerDelegate {
           editorArea.tabs[0].select();
           return;
         }
-        editorArea.selectFile(resource, switchesTab: true);
+        _selectFile(resource);
       });
     });
   }
@@ -366,7 +366,7 @@ class Spark extends Application implements FilesControllerDelegate {
 
       if (entry != null) {
         workspace.link(entry).then((file) {
-          editorArea.selectFile(file, forceOpen: true, switchesTab: true);
+          _selectFile(file);
           workspace.save();
         });
       }
@@ -381,7 +381,7 @@ class Spark extends Application implements FilesControllerDelegate {
 
       if (entry != null) {
         workspace.link(entry).then((file) {
-          editorArea.selectFile(file, forceOpen: true, switchesTab: true);
+          _selectFile(file);
           workspace.save();
         });
       }
@@ -405,10 +405,15 @@ class Spark extends Application implements FilesControllerDelegate {
 
   List<ws.Resource> _getSelection() => _filesController.getSelection();
 
-   void _closeOpenEditor(ws.Resource resource) {
+  void _closeOpenEditor(ws.Resource resource) {
     if (resource is ws.File &&  editorManager.isFileOpened(resource)) {
       editorManager.close(resource);
     }
+  }
+
+  void _selectFile(ws.Resource file) {
+    editorArea.selectFile(file,
+        forceOpen: true, switchesTab: true, forceFocus: true);
   }
 
   void showStatus(String text) {


### PR DESCRIPTION
fixes #483 

Fixes an issue where the active editor and the files view were fighting for focus. Now, an editor becomes focused if the user explicitly clicks on a tab header or the file is opened via an explicit user action (e.g., new file). Just selecting a file in the files view will not cause focus to shift to the editing area.

@umop for review
