### PR TITLE
Fix up paths for checked mode

### DIFF
--- a/widgets/lib/spark-icon-button/spark-icon-button.html
+++ b/widgets/lib/spark-icon-button/spark-icon-button.html
@@ -16,7 +16,7 @@
  */
 -->
 
-<link rel="import" href="../spark-icon/spark-icon.html">
+<link rel="import" href="../../../packages/spark_widgets/spark-icon/spark-icon.html">
 
 <polymer-element name="spark-icon-button" attributes="src active">
   <template>

--- a/widgets/lib/spark-menu-button/spark-menu-button.html
+++ b/widgets/lib/spark-menu-button/spark-menu-button.html
@@ -10,9 +10,9 @@
  */
 -->
 
-<link rel="import" href="../spark-icon-button/spark-icon-button.html"/>
-<link rel="import" href="../spark-overlay/spark-overlay.html">
-<link rel="import" href="../spark-menu/spark-menu.html"/>
+<link rel="import" href="../../../packages/spark_widgets/spark-icon-button/spark-icon-button.html"/>
+<link rel="import" href="../../../packages/spark_widgets/spark-overlay/spark-overlay.html">
+<link rel="import" href="../../../packages/spark_widgets/spark-menu/spark-menu.html"/>
 
 <polymer-element name="spark-menu-button"
     attributes="src,

--- a/widgets/lib/spark-menu-item/spark-menu-item.html
+++ b/widgets/lib/spark-menu-item/spark-menu-item.html
@@ -12,7 +12,7 @@
  */
 -->
 
-<link rel="import" href="../spark-icon/spark-icon.html">
+<link rel="import" href="../../../packages/spark_widgets/spark-icon/spark-icon.html">
 
 <polymer-element name="spark-menu-item" attributes="src label iconsize">
   <template>

--- a/widgets/lib/spark-menu/spark-menu.html
+++ b/widgets/lib/spark-menu/spark-menu.html
@@ -23,7 +23,7 @@
  */
 -->
 
-<link rel="import" href="../spark-selector/spark-selector.html">
+<link rel="import" href="../../../packages/spark_widgets/spark-selector/spark-selector.html">
 
 <polymer-element name="spark-menu" extends="spark-selector">
   <template>

--- a/widgets/lib/spark-selector/spark-selector.html
+++ b/widgets/lib/spark-selector/spark-selector.html
@@ -45,7 +45,7 @@
  */
 -->
 
-<link rel="import" href="../spark-selection/spark-selection.html">
+<link rel="import" href="../../../packages/spark_widgets/spark-selection/spark-selection.html">
 
 <polymer-element name="spark-selector"
     attributes="selected,


### PR DESCRIPTION
@ussuri 

This will make Spark run in checked mode.  Note there is a fix that is being made to the Dart polymer loader, the package root is not quite right for extension.  Once that fix is pushed the Spark code works (tried with a hand patch of the fix from Siggi).

This change does allow the unchecked code to still work.
