### PR TITLE
apply grind 4.4

### DIFF
--- a/ide/tool/drone_io.sh
+++ b/ide/tool/drone_io.sh
@@ -6,7 +6,6 @@ fi
 
 # Setup the build environment.
 pub get 
-./grind setup          
 
 # Build the archive.
 ./grind archive

--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -46,7 +46,7 @@ void setup(GrinderContext context) {
   }
 
   PubTools pub = new PubTools();
-  pub.install(context);
+  pub.get(context);
 
   _populateSdk(context);
 


### PR DESCRIPTION
`archive` task has dependency on `setup` task, so no need to run `setup` task.

@devoncarew 
