### PR TITLE
Patched the spark_widgets imports to work around a Polymer shortcoming

### DIFF
--- a/ide/app/lib/polymer_ui/spark_polymer_ui.dart
+++ b/ide/app/lib/polymer_ui/spark_polymer_ui.dart
@@ -5,7 +5,9 @@
 library spark_polymer.ui;
 
 import 'package:polymer/polymer.dart';
-import 'package:spark_widgets/common/widget.dart';
+
+// BUG(ussuri): https://github.com/dart-lang/spark/issues/500
+import '../../packages/spark_widgets/common/widget.dart';
 
 @CustomTag('spark-polymer-ui')
 class SparkPolymerUI extends Widget {

--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -9,7 +9,9 @@ import 'dart:html';
 
 import 'package:bootjack/bootjack.dart' as bootjack;
 import 'package:polymer/polymer.dart' as polymer;
-import 'package:spark_widgets/spark-overlay/spark-overlay.dart' as widgets;
+
+// BUG(ussuri): https://github.com/dart-lang/spark/issues/500
+import '../packages/spark_widgets/spark-overlay/spark-overlay.dart' as widgets;
 
 import 'spark.dart';
 import 'lib/actions.dart';

--- a/widgets/lib/spark-menu-button/spark-menu-button.dart
+++ b/widgets/lib/spark-menu-button/spark-menu-button.dart
@@ -5,9 +5,9 @@
 library spark_widgets.menu_button;
 
 import 'package:polymer/polymer.dart';
-import 'package:spark_widgets/spark-menu/spark-menu.dart';
 
 import '../common/widget.dart';
+import '../spark-menu/spark-menu.dart';
 
 // Ported from Polymer Javascript to Dart code.
 

--- a/widgets/lib/spark-menu/spark-menu.dart
+++ b/widgets/lib/spark-menu/spark-menu.dart
@@ -4,8 +4,9 @@
 
 library spark_widgets.menu;
 
-import 'package:spark_widgets/spark-selector/spark-selector.dart';
 import 'package:polymer/polymer.dart';
+
+import '../spark-selector/spark-selector.dart';
 
 // Ported from Polymer Javascript to Dart code.
 


### PR DESCRIPTION
See https://github.com/dart-lang/spark/issues/500.

Changes in spark_widgets themselves are not marked with a "// BUG" because they are good ones overall, and they didn't go as far as the others (the ".../packages/spark_widgets..." part appeared to be unnecessary).

TBR: @terrylucas
