### PR TITLE
Increased spark-overlay starting z-index

### DIFF
--- a/widgets/lib/spark-overlay/spark-overlay.dart
+++ b/widgets/lib/spark-overlay/spark-overlay.dart
@@ -47,7 +47,7 @@ class SparkOverlay extends Widget {
     return overlays.isNotEmpty ? overlays.last : null;
   }
 
-  static int DEFAULT_Z = 10;
+  static int DEFAULT_Z = 1000;
 
   static currentOverlayZ() {
     var z = DEFAULT_Z;

--- a/widgets/lib/spark-overlay/spark-overlay.html
+++ b/widgets/lib/spark-overlay/spark-overlay.html
@@ -99,7 +99,7 @@
       @host {
         * {
           position: fixed;
-          z-index: 10;
+          z-index: 1000;
           outline: none;
           display: none;
           opacity: 0.99;


### PR DESCRIPTION
This fixes https://github.com/dart-lang/spark/issues/511 (the menu shown underneath the tabs).

TBR: @terrylucas
