### PR TITLE
error message for pub get

### DIFF
--- a/ide/grind
+++ b/ide/grind
@@ -3,6 +3,11 @@
 # All rights reserved. Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+if [ ! -d "packages" ]; then
+  echo "Unable to find dependency pacakges."
+  echo "Please execute> pub get"
+fi
+
 DART_VER=$(dart --version 2>&1)
 if [[ "$DART_VER" != Dart\ VM\ version:* ]] ; then
   echo "Unable to execute dart. Please set the DART_SDK environment variable to"


### PR DESCRIPTION
TEST=./grind  (before pub get), ./grind (after pub get)

The result is

sungguk@sungguk-Satellite-M100:~/program_store/spark/ide$ ./grind 
Unable to find dependency pacakges.
Please execute> pub get
Unable to open file: /home/sungguk/program_store/spark/ide/tool/packages/grinder/grinder.dart'file:///home/sungguk/program_store/spark/ide/tool/grind.dart': error: line 8 pos 1: library handler failed
import 'package:grinder/grinder.dart';
