### PR TITLE
peg dquery to a specific version

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -11,18 +11,18 @@ dependencies:
   bootjack: any
   browser: any
   chrome_gen: '>=0.3.2'
-  crc32: 0.1.3
+  crc32: '>=0.1.3'
   crypto: any
+  dquery: 0.5.3+7
   intl: any
   logging: any
   mime: any
+  path: any
   polymer: '>=0.9.2'
   spark_widgets:
     path: ../widgets
   unittest: any
   uuid: any
-dependency_overrides:
-  path: '>=1.0.0'
 dev_dependencies:
   args: any
   grinder: '>=0.4.5'


### PR DESCRIPTION
TBR. This:
- pegs `dquery` to a specific version - the latest latest version has an issue running against the dev SDK
- adds an explicit `path` dependency, as it's no longer just a transitive dependency
- remove the `path` version override; the version that comes in by default now _is_ 1.0.0 or greater

@keertip 
