### PR TITLE
PolymerUI : Do nothing when outside of modal dialog clicked

### DIFF
--- a/widgets/lib/spark-modal/spark-modal.dart
+++ b/widgets/lib/spark-modal/spark-modal.dart
@@ -4,6 +4,7 @@
 
 library spark_widgets.menu;
 
+import 'dart:html';
 import 'package:polymer/polymer.dart';
 
 import '../spark-overlay/spark-overlay.dart';
@@ -13,4 +14,12 @@ import '../spark-overlay/spark-overlay.dart';
 @CustomTag("spark-modal")
 class SparkModal extends SparkOverlay {
   SparkModal.created(): super.created();
+
+  @override
+  void captureHandler(MouseEvent e) {
+    if (!pointInOverlay(this, e.client)) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+    }
+  }
 }


### PR DESCRIPTION
When outside of modal dialog is clicked, `captureHandler` of spark-overlay is called.
To prevent closing modal dialog, make it do nothing except `e.stopImmediatePropagation()` and `e.preventDefault()`

Fix=https://github.com/dart-lang/spark/issues/528
Test=manual
review=@ussuri
