### PR TITLE
Fixed commit functionality.

### DIFF
--- a/ide/app/lib/git/commands/commit.dart
+++ b/ide/app/lib/git/commands/commit.dart
@@ -142,8 +142,9 @@ class Commit {
         commitContent.write(dateString);
         commitContent.write('\n\n${commitMsg}\n');
 
-        return store.writeRawObject('commit', commitContent.toString()).then(
-            (String commitSha) {
+        return store.writeRawObject(
+            ObjectTypes.COMMIT, commitContent.toString()).then(
+                (String commitSha) {
           return FileOps.createFileWithContent(dir, '.git/${refName}',
               commitSha + '\n', 'Text').then((_) {
                 return store.updateLastChange(null).then((_) => commitSha);

--- a/ide/app/lib/git/commands/commit.dart
+++ b/ide/app/lib/git/commands/commit.dart
@@ -7,8 +7,6 @@ library git.commands.commit;
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'dart:html';
-
 import 'package:chrome_gen/chrome_app.dart' as chrome;
 
 import '../file_operations.dart';
@@ -119,31 +117,31 @@ class Commit {
     return walkFiles(dir, store).then((String sha) {
       return checkTreeChanged(store, parent, sha).then((_) {
         DateTime now = new DateTime.now();
-        String dateString = (now.millisecond / 1000).floor().toString();
-        int offset = (now.timeZoneOffset.inMilliseconds / -60).floor();
+        String dateString =
+            (now.millisecondsSinceEpoch / 1000).floor().toString();
+        int offset = (now.timeZoneOffset.inHours).floor();
         int absOffset = offset.abs().floor();
-        String offsetStr = '' + (offset < 0 ? '-' : '+');
+        String offsetStr = ' ' + (offset < 0 ? '-' : '+');
         offsetStr += (absOffset < 10 ? '0' : '') + '${absOffset}00';
         dateString += offsetStr;
-        List<String> commitParts = [];
-        commitParts.add('tree ${sha}\n');
+        StringBuffer commitContent = new StringBuffer();
+        commitContent.write('tree ${sha}\n');
         if (parent != null && parent.length) {
-          commitParts.add('parent ${parent}');
+          commitContent.write('parent ${parent}');
           if (parent[parent.length -1] != '\n') {
-            commitParts.add('\n');
+            commitContent.write('\n');
           }
         }
 
-        commitParts.add('author ${name} ');
-        commitParts.add(' <$email> ');
-        commitParts.add(dateString);
-        commitParts.add('\n');
-        commitParts.add('committer ${name}');
-        commitParts.add(' <${email}>');
-        commitParts.add(dateString);
-        commitParts.add('\n\n${commitMsg}\n');
+        commitContent.write('author ${name} ');
+        commitContent.write(' <$email> ');
+        commitContent.write(dateString);
+        commitContent.write('\n');
+        commitContent.write('committer ${name}');
+        commitContent.write(' <${email}> ');
+        commitContent.write(dateString);
+        commitContent.write('\n\n${commitMsg}\n');
 
-        StringBuffer commitContent = new StringBuffer(commitParts);
         return store.writeRawObject('commit', commitContent.toString()).then(
             (String commitSha) {
           return FileOps.createFileWithContent(dir, '.git/${refName}',

--- a/ide/app/lib/git/object.dart
+++ b/ide/app/lib/git/object.dart
@@ -157,10 +157,19 @@ class CommitObject extends GitObject {
   String _message;
   String treeSha;
 
-  CommitObject(String sha, Uint8List data) {
+  CommitObject(String sha, var data) {
     this._type = ObjectTypes.COMMIT;
     this._sha = sha;
-    this.data = UTF8.decode(data);
+
+    if (data is Uint8List) {
+      this.data = UTF8.decode(data);
+    } else if (data is String) {
+      this.data = data;
+    } else {
+      // TODO: Clarify this exception.
+      throw "Data is in incompatible format.";
+    }
+
     _parseData();
   }
 
@@ -179,7 +188,7 @@ class CommitObject extends GitObject {
     String authorLine = lines[i].replaceFirst("author ", "");
     author = _parseAuthor(authorLine);
 
-    var committerLine = lines[i + 1].replaceFirst("committer ", "");
+    String committerLine = lines[i + 1].replaceFirst("committer ", "");
     committer = _parseAuthor(committerLine);
 
     if (lines[i + 2].split(" ")[0] == "encoding") {
@@ -241,10 +250,10 @@ class LooseObject {
 
   // Parses and constructs a loose git object.
   void _parse(buf) {
-    Uint8List data = new Uint8List(buf);
     String header;
     int i;
     if (buf is chrome.ArrayBuffer) {
+     Uint8List data = new Uint8List.fromList(buf);
       List<String> headChars = [];
       for (i = 0; i < data.length; ++i) {
         if (data[i] != 0)
@@ -257,7 +266,7 @@ class LooseObject {
       this.data = data.sublist(i + 1, data.length);
     } else {
       String data = buf;
-      i = data.indexOf('\0)');
+      i = data.indexOf(new String.fromCharCode(0));
       header = data.substring(0, i);
       // move past null terminator but keep zlib header
       this.data = data.substring(i + 1, data.length);

--- a/ide/app/lib/git/object.dart
+++ b/ide/app/lib/git/object.dart
@@ -164,7 +164,6 @@ class CommitObject extends GitObject {
     _parseData();
   }
 
-
   // Parses the byte stream and constructs the commit object.
   void _parseData() {
     List<String> lines = data.split("\n");
@@ -201,7 +200,7 @@ class CommitObject extends GitObject {
     Author author = new Author();
     author.name = match[0].group(1);
     author.email = match[0].group(2);
-    author.timestamp = int.parse(match[0].group(3));
+    author.timestamp = (int.parse(match[0].group(3))) * 1000;
     author.date = new DateTime.fromMillisecondsSinceEpoch(
         author.timestamp, isUtc:true);
     return author;

--- a/ide/app/lib/git/objectstore.dart
+++ b/ide/app/lib/git/objectstore.dart
@@ -497,7 +497,6 @@ class ObjectStore {
     };
 
     reader.callMethod('readAsArrayBuffer', [new Blob(blobParts)]);
-
     return completer.future;
   }
 
@@ -546,15 +545,10 @@ class ObjectStore {
   }
 
   Future<GitConfig> getConfig() {
-    Completer completer = new Completer();
-
-    FileOps.readFile(_rootDir, '.git/config.json', 'Text').then(
-        (String configStr) => completer.complete(new GitConfig(configStr)),
-      onError: (e) {
-        // TODO: handle errors / build default GitConfig.
-        completer.complete(new GitConfig());
-      });
-    return completer.future;
+    return FileOps.readFile(_rootDir, '.git/config.json', 'Text').then(
+        (String configStr) => new GitConfig(configStr),
+      // TODO: handle errors / build default GitConfig.
+      onError: (e) => new GitConfig());
   }
 
   Future<Entry> setConfig(GitConfig config) {

--- a/ide/app/lib/git/objectstore.dart
+++ b/ide/app/lib/git/objectstore.dart
@@ -209,7 +209,6 @@ class ObjectStore {
 
   Future<GitObject> retrieveObject(String sha, String objType) {
     String dataType = (objType == ObjectTypes.COMMIT ? "Text" : "ArrayBuffer");
-
     return retrieveRawObject(sha, dataType).then(
         (LooseObject object) => GitObject.make(sha, objType, object.data));
   }
@@ -232,10 +231,9 @@ class ObjectStore {
           var buff;
           return new LooseObject(buff);
         } else {
-          return FileOps.readBlob(new Blob(inflated.getBytes()), 'Text').then(
-              (data) {
-            return new LooseObject(data);
-          });
+          return FileOps.readBlob(new Blob(
+              [new Uint8List.fromList(inflated.getBytes())]), 'Text').then(
+              (data) => new LooseObject(data));
         }
       });
     }, onError:(e) {
@@ -455,6 +453,11 @@ class ObjectStore {
       size = content.length;
     } else if (content is Blob) {
       size = content.size;
+    } else if (content is String) {
+      size = content.length;
+    } else {
+      // TODO: Check expected types here.
+      throw "Unexpected content type.";
     }
 
     String header = 'type ${size}' ;

--- a/ide/app/lib/git/objectstore.dart
+++ b/ide/app/lib/git/objectstore.dart
@@ -460,8 +460,7 @@ class ObjectStore {
       throw "Unexpected content type.";
     }
 
-    String header = 'type ${size}' ;
-
+    String header = '${type} ${size}' ;
     blobParts.add(header);
     blobParts.add(new Uint8List.fromList([0]));
     blobParts.add(content);
@@ -542,7 +541,7 @@ class ObjectStore {
   Future<String> writeTree(List treeEntries) {
     List blobParts = [];
     treeEntries.forEach((TreeEntry tree) {
-      blobParts.add(tree.isBlob ? '100644 ' : '40000 ' + tree.name);
+      blobParts.add(tree.isBlob ? '100644 ' : '040000 ' + tree.name);
       blobParts.add(new Uint8List.fromList([0]));
       blobParts.add(tree.sha);
     });

--- a/ide/app/lib/git/utils.dart
+++ b/ide/app/lib/git/utils.dart
@@ -5,23 +5,23 @@
 library git.utils;
 
 import 'dart:core';
+import 'dart:typed_data';
 
 /**
  * Convertes [sha] string to sha bytes.
  */
-List<int> shaToBytes(String sha) {
+Uint8List shaToBytes(String sha) {
   List<int> bytes = [];
-
   for (var i = 0; i < sha.length; i+=2) {
     bytes.add(int.parse('0x' + sha[i] + sha[i+1]));
   }
-  return bytes;
+  return new Uint8List.fromList(bytes);
 }
 
 /**
  * Converts [shaBytes] to HEX string.
  */
-String shaBytesToString(List<int> shaBytes) {
+String shaBytesToString(Uint8List shaBytes) {
   String sha = "";
   shaBytes.forEach((int byte) {
     String shaPart = byte.toRadixString(16);


### PR DESCRIPTION
Commit command is issues are repaired.
- Changed some functions to use Completers rather than chaining together returns.
- Added error throwing with basic errors for testing.

Note:
running 

```
Completer completer = new Completer
...
[synchronous code]
completer.complete()
[synchronous code]
...
return completer.future;
```

unfortunately does not work - the completer.future must be return before the completer is completed! (i.e. the code with the completer.complete() must be run async.
Instances of this are fixed by replacing the synchronous block with an embedded function, and

```
return new Future.sync(() => findPack());
```

enabling the future return format.

Also fixed a problem in retrieveObject - the result from the reader may be an ArrayBuffer or a ByteBuffer. Fix copied from a similar use-case elsewhere in the Git codebase.

_storeInFile is fixed to note that ChrFileEntry.fileWriter is not yet implemented. writeBytes works as a substitute until fileWrite is implemented.

getConfig() is fixed to handle the case (which occurs every initial commit) where the GitConfig string is null. This needs to be enhanced in the future.
