### PR TITLE
add tooltips to the icon buttons

### DIFF
--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -229,8 +229,10 @@
     </style>
 
     <spark-toolbar id="toolbar" color="white" lightdom>
-      <spark-icon-button id="openFile" src="images/open.png"></spark-icon-button>
-      <spark-icon-button id="newFile" src="images/add.png"></spark-icon-button>
+      <spark-icon-button id="openFile" tooltip="Open File..." src="images/open.png">
+      </spark-icon-button>
+      <spark-icon-button id="newFile" tooltip="New File..." src="images/add.png">
+      </spark-icon-button>
 
       <span id="saveStatus"></span>
 

--- a/widgets/lib/spark_icon/spark_icon.dart
+++ b/widgets/lib/spark_icon/spark_icon.dart
@@ -17,5 +17,7 @@ class SparkIcon extends Widget {
   /// Size of the icon defaults to 24.
   @published String size = "24";
 
+  @published String tooltip = "";
+
   SparkIcon.created(): super.created();
 }

--- a/widgets/lib/spark_icon/spark_icon.html
+++ b/widgets/lib/spark_icon/spark_icon.html
@@ -20,7 +20,7 @@
  */
 -->
 
-<polymer-element name="spark-icon" attributes="src size">
+<polymer-element name="spark-icon" attributes="src tooltip size">
   <template>
     <style>
       @host {
@@ -41,7 +41,8 @@
     </style>
 
     <div id="icon"
-        style="background-image:url({{src}}); width:{{size}}px; height:{{size}}px">
+        style="background-image:url({{src}}); width:{{size}}px; height:{{size}}px"
+        title="{{tooltip}}">
     </div>
   </template>
 

--- a/widgets/lib/spark_icon_button/spark_icon_button.dart
+++ b/widgets/lib/spark_icon_button/spark_icon_button.dart
@@ -12,6 +12,7 @@ import '../common/widget.dart';
 @CustomTag("spark-icon-button")
 class SparkIconButton extends Widget {
   @published String src = "";
+  @published String tooltip = "";
   @published bool active = false;
 
   SparkIconButton.created(): super.created();

--- a/widgets/lib/spark_icon_button/spark_icon_button.html
+++ b/widgets/lib/spark_icon_button/spark_icon_button.html
@@ -18,7 +18,7 @@
 
 <link rel="import" href="../../../packages/spark_widgets/spark_icon/spark_icon.html">
 
-<polymer-element name="spark-icon-button" attributes="src active">
+<polymer-element name="spark-icon-button" attributes="src tooltip active">
   <template>
     <style>
       @host {
@@ -56,7 +56,7 @@
       }
     </style>
 
-    <spark-icon src="{{src}}"></spark-icon>
+    <spark-icon src="{{src}}" tooltip="{{tooltip}}"></spark-icon>
   </template>
 
   <script type="application/dart" src="spark_icon_button.dart"></script>


### PR DESCRIPTION
Add tooltips to the toolbar icons. This is to partially address #609. Using fixed background images in the polymer spark_icon_button doesn't leave us with a lot of control over the button's size and look.

@ussuri 
