### PR TITLE
misc polymer cleanups

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -274,7 +274,6 @@ class KeyBindingManager {
   }
 
   void _updateName(String name) {
-    _label.text =
-        'Keys: ' + (name == null ? 'default' : utils.capitalize(name));
+    _label.text = (name == null ? 'default' : utils.capitalize(name));
   }
 }

--- a/ide/app/lib/ui/widgets/tabview.css
+++ b/ide/app/lib/ui/widgets/tabview.css
@@ -57,8 +57,8 @@
 .tabview-tablabel {
   -webkit-user-select: none;
   align-items: center;
-  border: 1px solid transparent;
-  border-bottom: none;
+  border: 1px solid #CCC;
+  border-bottom: 1px solid #CCC;
   border-radius: 5px 5px 0 0;
   box-sizing: border-box;
   cursor: pointer;
@@ -83,8 +83,8 @@
 }
 
 .tabview-tablabel-active {
-  background: -webkit-linear-gradient(bottom, #EEE, white);
-  border: 1px solid #CCC;
+  background: -webkit-linear-gradient(bottom, #DDD, white);
+  border: 1px solid #DDD;
   border-bottom: 1px solid #EEE;
   margin-top: 5px;
   margin-bottom: 0;
@@ -92,8 +92,13 @@
   position: relative;
 }
 
-.tabview-tablabel:hover .tabview-tablabel-caption {
-  color: #448;
+.tabview-tablabel:hover {
+  background: #F3F3F3;
+}
+
+.tabview-tablabel-active:hover {
+  background: -webkit-linear-gradient(bottom, #CCC, white);
+  border-bottom: 1px solid #CCC;
 }
 
 .tabview-tablabel-caption {
@@ -104,13 +109,12 @@
 }
 
 .tabview-tablabel-closebutton {
-  opacity: 0;
+  opacity: 0.2;
   display: none;
-  opacity: 0;
   position: absolute;
-  top: 1px;
-  right: 6px;
-  font-size: 18px;
+  top: 3px;
+  right: 4px;
+  font-size: 16px;
 }
 
 .tabview-tablabel-closable .tabview-tablabel-closebutton {
@@ -118,18 +122,19 @@
 }
 
 .tabview-tablabel-active .tabview-tablabel-closebutton {
-  opacity: 0.2;
+  opacity: 0.5;
 }
 
 .tabview-tablabel:hover .tabview-tablabel-closebutton {
-  opacity: 0.2;
+  opacity: 0.5;
 }
 
 .tabview-tablabel-closebutton:hover {
-  opacity: 0.4;
+  opacity: 0.8;
 }
+
 .tabview-tablabel:hover .tabview-tablabel-closebutton:hover {
-  opacity: 0.4;
+  opacity: 0.8;
 }
 
 .tabview-workspace {

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -235,9 +235,9 @@ class Spark extends SparkModel implements FilesControllerDelegate {
   void createEditorComponents() {
     _aceContainer = new AceContainer(new DivElement());
     _aceThemeManager = new ThemeManager(
-        aceContainer, syncPrefs, getUIElement('#changeTheme a span'));
+        aceContainer, syncPrefs, getUIElement('#changeTheme span'));
     _aceKeysManager = new KeyBindingManager(
-        aceContainer, syncPrefs, getUIElement('#changeKeys a span'));
+        aceContainer, syncPrefs, getUIElement('#changeKeys span'));
     _editorManager = new EditorManager(
         workspace, aceContainer, localPrefs, eventBus);
     _editorArea = new EditorArea(

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -32,7 +32,7 @@
 
 #saveStatus {
   flex: 1;
-  color: #ccc;
+  color: #aaa;
   margin-left: 6px;
   vertical-align: bottom;
   white-space: nowrap;
@@ -157,14 +157,19 @@
 }
 
 #editedFilename {
-  color: #ccc;
+  color: #aaa;
   display: inline-block;
-  margin-right: 10px;
+  margin: 0 6px 0 0;
   max-width: 200px;
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: middle;
   white-space: nowrap;
+}
+
+.titleFont {
+  font-family: Helvetica, Sans-serif;
+  font-size: 14px;  
 }
 
 #editedFilename.hidden {
@@ -218,6 +223,7 @@
   font-size: 18pt;
   vertical-align: middle;
   color: #777;
+  margin: 0;
 }
 
 /* TODO(ussuri): None of these worked. Fix.
@@ -241,10 +247,11 @@
       <spark-icon-button id="newFile" tooltip="New File..." src="images/add.png">
       </spark-icon-button>
 
-      <span id="saveStatus"></span>
+      <span id="saveStatus" class="titleFont"></span>
 
-      <div id="toolbarRight">
+      <div id="toolbarRight" class="titleFont">
         <span id="editedFilename"></span>
+        
         <i id="activitySpinner" class="fa fa-spinner fa-spin"></i>
 
         <spark-menu-button id="hotdogMenuNew"
@@ -258,8 +265,8 @@
           </spark-menu-item>
           <spark-menu-item action-id="folder-open" iconsize=0 label="Open Folder...">
           </spark-menu-item>
-          <spark-menu-item id="changeTheme" iconsize=0>
-            <a><span></span></a>
+          <spark-menu-item id="changeTheme" iconsize=0 label="Theme:">
+            <span></span>
             <span class="plus-minus-container">
               <label class="plus-minus-spacer"></label>
               <spark-button class="plus-minus" on-click="{{onThemeMinus}}">
@@ -270,8 +277,8 @@
               </spark-button>
             </span>
           </spark-menu-item>
-          <spark-menu-item id="changeKeys" iconsize=0>
-            <a><span></span></a>
+          <spark-menu-item id="changeKeys" iconsize=0 label="Keys:">
+            <span></span>
             <span class="plus-minus-container">
               <label class="plus-minus-spacer"></label>
               <spark-button class="plus-minus" on-click="{{onKeysMinus}}">

--- a/widgets/lib/spark_icon_button/spark_icon_button.html
+++ b/widgets/lib/spark_icon_button/spark_icon_button.html
@@ -34,7 +34,6 @@
           cursor: pointer;
           border: none;
           background-color: rgba(0, 0, 0, 0);
-          background-position: top left;
           background-size: cover;
           background-repeat: no-repeat;
           background-image: url("packages/spark_widgets/spark_icon_button/btn_light.png");

--- a/widgets/lib/spark_menu/spark_menu.html
+++ b/widgets/lib/spark_menu/spark_menu.html
@@ -37,14 +37,13 @@
         line-height: 35px;
         padding: 0 10px;
         margin: 10px;
-        -webkit-transform: translate3d(0, 0, 0);
         border-radius: 3px;
         border: 1px solid transparent;
-        font-weight: bold;
-        font-size: 15px;
+        font-family: Helvetica, Sans-serif;
+        font-size: 14px;
         cursor: pointer;
         white-space: nowrap;
-        opacity: .5;
+        color: #555;
       }
 
       /* TODO(sorvell): please note, styling broken due to:
@@ -54,7 +53,6 @@
       shadow::-webkit-distributed(spark-menu-item.selected) {
         background: #f2f2f2;
         border: 1px solid rgba(0, 0, 0, 0.15);
-        opacity: 0.9;
       }
     </style>
 

--- a/widgets/lib/spark_menu_item/spark_menu_item.html
+++ b/widgets/lib/spark_menu_item/spark_menu_item.html
@@ -18,7 +18,7 @@
   <template>
     <style>
       .labelText {
-        margin: 0 15px;
+        margin: 0 5px;
       }
 
       spark-icon, .labelText, .labelText > * {

--- a/widgets/lib/spark_splitter/spark_splitter.html
+++ b/widgets/lib/spark_splitter/spark_splitter.html
@@ -39,22 +39,21 @@
       @host {
         * {
           display: block;
-          width: 10px;
-          background: #efefef url(packages/spark_widgets/spark_splitter/handle.png) no-repeat center;
-          box-shadow: inset 0 0 2px 1px #ccc;
-          opacity: 0.9;
+          width: 6px;
+          border-left: 1px solid #DDD;
+          border-right: 1px solid #DDD;
           cursor: col-resize;
+          background-color: #F7F7F7;
         }
 
         .horizontal {
           width: auto;
-          height: 10px;
+          height: 6px;
           cursor: row-resize;
-          background-image: url(packages/spark_widgets/spark-splitter/handle_horiz.png) no-repeat center;
         }
 
         :hover, .active {
-          background-color: #ddd;
+          
         }
       }
     </style>


### PR DESCRIPTION
Misc UI cleanups from the polymer changeover:
- fixed an issue where two menu item looked like hyperlinks when they weren't
- fixed an issue where the menu text was blurry (translate3d(0, 0, 0))
- fixed a font and sizing issue with the 'x' in the tabview tab headers
- save status, editor filename (in toolbar), and menu items all get the same font
- polymer splitter gets a little narrower, and the grab icon was removed (it was not centered, and didn't seem to be necessary)

@dinhviethoa @ussuri 
