### PR TITLE
add an abstraction layer for SCM support

### DIFF
--- a/ide/app/test/all.dart
+++ b/ide/app/test/all.dart
@@ -20,6 +20,7 @@ import 'files_test.dart' as files_test;
 import 'jobs_test.dart' as jobs_test;
 import 'git/all.dart' as git_all_test;
 import 'preferences_test.dart' as preferences_test;
+import 'scm_test.dart' as scm_test;
 import 'sdk_test.dart' as sdk_test;
 import 'server_test.dart' as server_test;
 import 'tcp_test.dart' as tcp_test;
@@ -43,6 +44,7 @@ void defineTests() {
   jobs_test.defineTests();
   git_all_test.defineTests();
   preferences_test.defineTests();
+  scm_test.defineTests();
   sdk_test.defineTests();
   server_test.defineTests();
   tcp_test.defineTests();

--- a/ide/app/test/scm_test.dart
+++ b/ide/app/test/scm_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library scm_test;
+
+import 'package:unittest/unittest.dart';
+
+import '../lib/scm.dart' as scm;
+
+defineTests() {
+  group('scm', () {
+    test('getProviders', () {
+      expect(scm.getProviders().length, 1);
+    });
+
+    test('get git provider', () {
+      expect(scm.getProviderType('grit'), isNull);
+      expect(scm.getProviderType('git'), isNotNull);
+      expect(scm.getProviderType('git').id, 'git');
+    });
+  });
+}


### PR DESCRIPTION
Gaurav, I'd like to add a bit of a higher level API to serve as an abstraction over source control management in Spark. I think this'll help us manage a bit better how to integrate Git into Spark. In particular, I think this will help as a bit with #631, in terms of knowing what operations and actions are available for different projects. This PR is a stab at that abstraction layer; I'd like to get your thoughts!

@gaurave for review
