### PR TITLE
add a FocusManager class, to track the current file the user has selecte...

### DIFF
--- a/ide/app/lib/app.dart
+++ b/ide/app/lib/app.dart
@@ -9,6 +9,8 @@ library spark.app;
 
 import 'dart:async';
 
+import 'workspace.dart';
+
 /**
  * A representation of an application. An application has a lifecycle and other
  * objects can participate in the application's lifecycle state changes.
@@ -18,6 +20,8 @@ import 'dart:async';
  *     STARTING ==> STARTED ==> CLOSING ==> CLOSED
  */
 abstract class Application {
+  FocusManager focusManager = new FocusManager();
+
   LifecycleState _state;
   List<LifecycleParticipant> _participants = [];
 
@@ -148,4 +152,92 @@ abstract class LifecycleParticipant {
    * Return a [Future] to delay the lifecycle change, or `null` otherwise.
    */
   Future applicationClosed(Application application) => null;
+}
+
+/**
+ * This class is used to track user focus in the application. There are three
+ * types of user focus you can track:
+ *
+ * __Current [Resource].__ This tracks user selection in the Files view and the
+ * editor tabs. This can be `null` if there is no user selection. This will
+ * generate the highest number of change events.
+ *
+ * __Current [File] being edited.__ This tracks the file currently being edited
+ * in the editor tabs. This file can be different then the current seleciton in
+ * the Files view. In can be `null` if there are no open editors.
+ *
+ * __Currently selected [Project].__ This is derived from the stream of events
+ * from the current [Resource]. It changes whenever the currently selected
+ * project changes. It can be `null` if there is no selection or if the
+ * selected Resource is not in a project.
+ */
+class FocusManager {
+  StreamController<Resource> _resourceController = new StreamController.broadcast();
+  StreamController<File> _editedFileController = new StreamController.broadcast();
+  StreamController<Project> _projectController = new StreamController.broadcast();
+
+  Resource _currentResource;
+  File _currentEditedFile;
+
+  FocusManager();
+
+  /**
+   * Indicate that the currently selected [Resource] has changed. This will
+   * automatically fire project events if necessary.
+   */
+  void setCurrentResource(Resource resource) {
+    if (_currentResource == resource) return;
+
+    Project oldProject = currentProject;
+
+    _currentResource = resource;
+    _resourceController.add(resource);
+
+    if (oldProject != currentProject) {
+      _projectController.add(currentProject);
+    }
+  }
+
+  /**
+   * Indicate that the [File] currently being edited has changed. This will
+   * automatically fire resource and project events if necessary.
+   */
+  void setEditedFile(File file) {
+    if (_currentEditedFile == file) return;
+
+    _currentEditedFile = file;
+    setCurrentResource(file);
+    _editedFileController.add(file);
+  }
+
+  /**
+   * Retrieve the currently selected [Resource]; can be `null`.
+   */
+  Resource get currentResource => _currentResource;
+
+  /**
+   * Retrieve the [File] currently being edited; can be `null`.
+   */
+  File get currentEditedFile => _currentEditedFile;
+
+  /**
+   * Return the [Project] for the currently focused [Resource]; can be `null`.
+   */
+  Project get currentProject =>
+      _currentResource == null ? null : _currentResource.project;
+
+  /**
+   * Fires an event when the currently focused [Resource] changes.
+   */
+  Stream<Resource> get onResourceChange => _resourceController.stream;
+
+  /**
+   * Fires an event when the [File] being edited changes.
+   */
+  Stream<File> get onEditedFileChange => _editedFileController.stream;
+
+  /**
+   * Fires an event when the current [Project] changes.
+   */
+  Stream<Project> get onProjectChange => _projectController.stream;
 }

--- a/ide/app/lib/ui/files_controller.dart
+++ b/ide/app/lib/ui/files_controller.dart
@@ -7,6 +7,7 @@
  */
 library spark.ui.widgets.files_controller;
 
+import 'dart:async';
 import 'dart:convert' show JSON;
 import 'dart:html' as html;
 
@@ -38,6 +39,8 @@ class FilesController implements TreeViewDelegate {
   Map<String, List<String>> _childrenCache;
   // Preferences where to store tree expanded/collapsed state.
   preferences.PreferenceStore localPrefs = preferences.localStore;
+  // The file selection stream controller.
+  StreamController<Resource> _selectionController = new StreamController.broadcast();
 
   FilesController(Workspace workspace,
                   FilesControllerDelegate delegate,
@@ -90,6 +93,7 @@ class FilesController implements TreeViewDelegate {
     if (file is File) {
       _delegate.selectInEditor(file, forceOpen: forceOpen);
     }
+    _selectionController.add(file);
   }
 
   void selectFirstFile({bool forceOpen: false}) {
@@ -98,6 +102,11 @@ class FilesController implements TreeViewDelegate {
     }
     selectFile(_files[0], forceOpen: forceOpen);
   }
+
+  /**
+   * Listen for selection change events.
+   */
+  Stream<Resource> get onSelectionChange => _selectionController.stream;
 
   // Implementation of [TreeViewDelegate] interface.
 
@@ -155,6 +164,7 @@ class FilesController implements TreeViewDelegate {
       if (resource is File) {
         _delegate.selectInEditor(resource, forceOpen: true, replaceCurrent: true);
       }
+      _selectionController.add(resource);
     }
   }
 

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -185,6 +185,21 @@ class Spark extends SparkModel implements FilesControllerDelegate {
 
   PlatformInfo get platformInfo => _platformInfo;
 
+  /**
+   * Get the currently selected [Resource].
+   */
+  ws.Resource get currentResource => focusManager.currentResource;
+
+  /**
+   * Get the [File] currently being edited.
+   */
+  ws.File get currentEditedFile => focusManager.currentEditedFile;
+
+  /**
+   * Get the currently selected [Project].
+   */
+  ws.Project get currentProject => focusManager.currentProject;
+
   // TODO(ussuri): The below two methods are a temporary means to make Spark
   // reusable in SparkPolymer. Once the switch to Polymer is complete, they
   // will go away.
@@ -207,7 +222,6 @@ class Spark extends SparkModel implements FilesControllerDelegate {
 
   SparkDialog createDialog(Element dialogElement) =>
       new SparkBootjackDialog(dialogElement);
-
 
   //
   // Parts of ctor:
@@ -287,12 +301,16 @@ class Spark extends SparkModel implements FilesControllerDelegate {
         _filesController.selectFile(tab.file);
       }
       localPrefs.setValue('lastFileSelection', tab.file.path);
+      focusManager.setEditedFile(tab.file);
     });
   }
 
   void initFilesController() {
-    _filesController =
-        new FilesController(workspace, this, getUIElement('#fileViewArea'));
+    _filesController = new FilesController(
+        workspace, this, getUIElement('#fileViewArea'));
+    _filesController.onSelectionChange.listen((resource) {
+      focusManager.setCurrentResource(resource);
+    });
   }
 
   void initLookAndFeel() {

--- a/ide/app/test/app_test.dart
+++ b/ide/app/test/app_test.dart
@@ -8,7 +8,9 @@ import 'dart:async';
 
 import 'package:unittest/unittest.dart';
 
+import 'files_mock.dart';
 import '../lib/app.dart';
+import '../lib/workspace.dart';
 
 // TODO: test that adding a participant after start() has been called, calls
 // the lifecycle methods of that participant.
@@ -52,6 +54,39 @@ defineTests() {
       } on StateError catch (ex) {
         expect(true, true);
       }
+    });
+  });
+
+  group('app focus', () {
+    Workspace workspace = new Workspace();
+    Project project;
+    File file;
+
+    setUp(() {
+      MockFileSystem fs = new MockFileSystem();
+      fs.createFile('/myProject/test.txt');
+      return workspace.link(fs.getEntry('myProject')).then((Project p) {
+        project = p;
+        file = p.getChild('test.txt');
+      });
+    });
+
+    test('changing resources fires project event', () {
+      FocusManager manager = new FocusManager();
+      Future future = manager.onProjectChange.first.then((event) {
+        expect(event, project);
+      });
+      manager.setCurrentResource(file);
+      return future;
+    });
+
+    test('changing edited file fires resource event', () {
+      FocusManager manager = new FocusManager();
+      Future future = manager.onResourceChange.first.then((event) {
+        expect(event, file);
+      });
+      manager.setEditedFile(file);
+      return future;
     });
   });
 }


### PR DESCRIPTION
This adds a new `FocusManager` API, to allow us to track what file the user has selected / is editing. This may help us with #631, to let us track the current project and enable and disable actions appropriately.

The FocusManager:
- is notified by the Files view and the editor tabs about selection changes and the current file being edited
- provides getters for the currently selected resource, the current file being edited, and the currently selected project
- provides event streams for the 3 items above, so client's of the API can take action when any one of those items changes.

So for example, a Git branch command could listen to the FocusManager for project change events, and enable and disable itself based on whether the current project supported git. And, when invoked, it would be able to query the FocusManager to determine the current project.

@gaurave for review
