### PR TITLE
Minor fixes for usage errors.

### DIFF
--- a/ide/app/lib/git/commands/commit.dart
+++ b/ide/app/lib/git/commands/commit.dart
@@ -126,7 +126,7 @@ class Commit {
         dateString += offsetStr;
         StringBuffer commitContent = new StringBuffer();
         commitContent.write('tree ${sha}\n');
-        if (parent != null && parent.length) {
+        if (parent != null && parent.length > 0) {
           commitContent.write('parent ${parent}');
           if (parent[parent.length -1] != '\n') {
             commitContent.write('\n');

--- a/ide/app/lib/git/commands/merge.dart
+++ b/ide/app/lib/git/commands/merge.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library git.commands.checkout;
+library git.commands.merge;
 
 import 'dart:async';
 import 'dart:typed_data';

--- a/ide/app/lib/git/pack.dart
+++ b/ide/app/lib/git/pack.dart
@@ -10,7 +10,7 @@ import 'dart:core';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:archive/archive.dart' as archive;
+import 'package:archive/archive.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:utf/utf.dart';
 
@@ -302,7 +302,7 @@ class Pack {
 
       for (int i = 0; i < numObjects; ++i) {
         PackObject object = _matchObjectAtOffset(_offset);
-        object.crc = archive.getCrc32(data.sublist(object.offset, _offset));
+        object.crc = getCrc32(data.sublist(object.offset, _offset));
 
         // hold on to the data for delta style objects.
         switch (object.type) {


### PR DESCRIPTION
commit.dart =>
parent.length generates a Javascript warning due to a type error when using dart2js to generate Chrome App ready code.

merge.dart =>
minor naming fix for the library name

pack.dart =>
Eclipse was completely unable to "run as Chrome App" with "as archive" present; and getCrc32 works without archive. prepended... Ok to remove?
