### PR TITLE
rename only refactoring change

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -22,8 +22,8 @@ import 'utils.dart' as utils;
 
 export 'package:ace/ace.dart' show EditSession;
 
-class AceEditor extends Editor {
-  final AceContainer aceContainer;
+class TextEditor extends Editor {
+  final AceManager aceManager;
   final workspace.File file;
 
   StreamController _dirtyController = new StreamController.broadcast();
@@ -37,7 +37,7 @@ class AceEditor extends Editor {
 
   bool _dirty = false;
 
-  AceEditor(this.aceContainer, this.file);
+  TextEditor(this.aceManager, this.file);
 
   bool get dirty => _dirty;
 
@@ -50,16 +50,16 @@ class AceEditor extends Editor {
     }
   }
 
-  html.Element get element => aceContainer.parentElement;
+  html.Element get element => aceManager.parentElement;
 
   void activate() {
     // TODO:
 
   }
 
-  void resize() => aceContainer.resize();
+  void resize() => aceManager.resize();
 
-  void focus() => aceContainer.focus();
+  void focus() => aceManager.focus();
 
   Future save() {
     if (_dirty) {
@@ -73,7 +73,7 @@ class AceEditor extends Editor {
 /**
  * A wrapper around an Ace editor instance.
  */
-class AceContainer {
+class AceManager {
   static final KEY_BINDINGS = ace.KeyboardHandler.BINDINGS;
   // 2 light themes, 4 dark ones.
   static final THEMES = [
@@ -93,7 +93,7 @@ class AceContainer {
   StreamSubscription _markerSubscription;
   workspace.File currentFile;
 
-  AceContainer(this.parentElement) {
+  AceManager(this.parentElement) {
     _aceEditor = ace.edit(parentElement);
     _aceEditor.renderer.fixedWidthGutter = true;
     _aceEditor.highlightActiveLine = false;
@@ -233,17 +233,17 @@ class AceContainer {
 }
 
 class ThemeManager {
-  AceContainer aceContainer;
+  AceManager aceManager;
   PreferenceStore prefs;
   html.Element _label;
 
-  ThemeManager(this.aceContainer, this.prefs, this._label) {
+  ThemeManager(this.aceManager, this.prefs, this._label) {
     prefs.getValue('aceTheme').then((String value) {
       if (value != null) {
-        aceContainer.theme = value;
+        aceManager.theme = value;
         _updateName(value);
       } else {
-        _updateName(aceContainer.theme);
+        _updateName(aceManager.theme);
       }
     });
   }
@@ -259,12 +259,12 @@ class ThemeManager {
   }
 
   void _changeTheme(int direction) {
-    int index = AceContainer.THEMES.indexOf(aceContainer.theme);
-    index = (index + direction) % AceContainer.THEMES.length;
-    String newTheme = AceContainer.THEMES[index];
+    int index = AceManager.THEMES.indexOf(aceManager.theme);
+    index = (index + direction) % AceManager.THEMES.length;
+    String newTheme = AceManager.THEMES[index];
     prefs.setValue('aceTheme', newTheme);
     _updateName(newTheme);
-    aceContainer.theme = newTheme;
+    aceManager.theme = newTheme;
   }
 
   void _updateName(String name) {
@@ -273,14 +273,14 @@ class ThemeManager {
 }
 
 class KeyBindingManager {
-  AceContainer aceContainer;
+  AceManager aceManager;
   PreferenceStore prefs;
   html.Element _label;
 
-  KeyBindingManager(this.aceContainer, this.prefs, this._label) {
+  KeyBindingManager(this.aceManager, this.prefs, this._label) {
     prefs.getValue('keyBinding').then((String value) {
       if (value != null) {
-        aceContainer.setKeyBinding(value);
+        aceManager.setKeyBinding(value);
       }
       _updateName(value);
     });
@@ -297,13 +297,13 @@ class KeyBindingManager {
   }
 
   void _changeBinding(int direction) {
-    aceContainer.getKeyBinding().then((String name) {
-      int index = math.max(AceContainer.KEY_BINDINGS.indexOf(name), 0);
-      index = (index + direction) % AceContainer.KEY_BINDINGS.length;
-      String newBinding = AceContainer.KEY_BINDINGS[index];
+    aceManager.getKeyBinding().then((String name) {
+      int index = math.max(AceManager.KEY_BINDINGS.indexOf(name), 0);
+      index = (index + direction) % AceManager.KEY_BINDINGS.length;
+      String newBinding = AceManager.KEY_BINDINGS[index];
       prefs.setValue('keyBinding', newBinding);
       _updateName(newBinding);
-      aceContainer.setKeyBinding(newBinding);
+      aceManager.setKeyBinding(newBinding);
     });
   }
 

--- a/ide/app/lib/editors.dart
+++ b/ide/app/lib/editors.dart
@@ -22,7 +22,7 @@ final int _DELAY_MS = 500;
 
 /**
  * Classes implement this interface provides/refreshes editors for [Resource]s.
- * TODO(ikarienator): Abstract [AceEditor] so we can support more editor types.
+ * TODO(ikarienator): Abstract [TextEditor] so we can support more editor types.
  */
 abstract class EditorProvider {
   Editor createEditorForFile(File file);
@@ -56,7 +56,7 @@ abstract class Editor {
  */
 class EditorManager implements EditorProvider {
   final Workspace _workspace;
-  final ace.AceContainer _aceContainer;
+  final ace.AceManager _aceContainer;
   final PreferenceStore _prefs;
   final EventBus _eventBus;
 
@@ -230,7 +230,7 @@ class EditorManager implements EditorProvider {
             return;
           }
           // TODO: this explicit casting to AceEditor will go away in a future refactoring
-          (_editorMap[currentFile] as ace.AceEditor).setSession(state.session);
+          (_editorMap[currentFile] as ace.TextEditor).setSession(state.session);
           _selectedController.add(currentFile);
           _aceContainer.switchTo(state.session, state.file);
           _aceContainer.cursorPosition = state.cursorPosition;
@@ -272,8 +272,8 @@ class EditorManager implements EditorProvider {
 
   // EditorProvider
   Editor createEditorForFile(File file) {
-    ace.AceEditor editor =
-        _editorMap[file] != null ? _editorMap[file] : new ace.AceEditor(_aceContainer, file);
+    ace.TextEditor editor =
+        _editorMap[file] != null ? _editorMap[file] : new ace.TextEditor(_aceContainer, file);
     _editorMap[file] = editor;
     openFile(file);
     editor.onDirtyChange.listen((_) {

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -93,7 +93,7 @@ class Spark extends SparkModel implements FilesControllerDelegate {
   final JobManager jobManager = new JobManager();
   ActivitySpinner _activitySpinner;
 
-  AceContainer _aceContainer;
+  AceManager _aceManager;
   ThemeManager _aceThemeManager;
   KeyBindingManager _aceKeysManager;
   ws.Workspace _workspace;
@@ -166,7 +166,7 @@ class Spark extends SparkModel implements FilesControllerDelegate {
   // SparkModel interface:
   //
 
-  AceContainer get aceContainer => _aceContainer;
+  AceManager get aceManager => _aceManager;
   ThemeManager get aceThemeManager => _aceThemeManager;
   KeyBindingManager get aceKeysManager => _aceKeysManager;
   ws.Workspace get workspace => _workspace;
@@ -255,13 +255,13 @@ class Spark extends SparkModel implements FilesControllerDelegate {
   }
 
   void createEditorComponents() {
-    _aceContainer = new AceContainer(new DivElement());
+    _aceManager = new AceManager(new DivElement());
     _aceThemeManager = new ThemeManager(
-        aceContainer, syncPrefs, getUIElement('#changeTheme span'));
+        aceManager, syncPrefs, getUIElement('#changeTheme span'));
     _aceKeysManager = new KeyBindingManager(
-        aceContainer, syncPrefs, getUIElement('#changeKeys span'));
+        aceManager, syncPrefs, getUIElement('#changeKeys span'));
     _editorManager = new EditorManager(
-        workspace, aceContainer, localPrefs, eventBus);
+        workspace, aceManager, localPrefs, eventBus);
     _editorArea = new EditorArea(
         getUIElement('#editorArea'),
         getUIElement('#editedFilename'),
@@ -329,7 +329,7 @@ class Spark extends SparkModel implements FilesControllerDelegate {
   void initSplitView() {
     _splitView = new SplitView(getUIElement('#splitview'));
     _splitView.onResized.listen((_) {
-      aceContainer.resize();
+      aceManager.resize();
       syncPrefs.setValue('splitViewPosition', _splitView.position.toString());
     });
     syncPrefs.getValue('splitViewPosition').then((String position) {
@@ -580,7 +580,7 @@ class _SparkSetupParticipant extends LifecycleParticipant {
       spark.workspace.restore().then((value) {
         if (spark.workspace.getFiles().length == 0) {
           // No files, just focus the editor.
-          spark.aceContainer.focus();
+          spark.aceManager.focus();
         }
       });
     });

--- a/ide/app/spark_model.dart
+++ b/ide/app/spark_model.dart
@@ -24,7 +24,7 @@ abstract class SparkModel extends Application {
 
   bool get developerMode;
 
-  AceContainer get aceContainer;
+  AceManager get aceManager;
   ThemeManager get aceThemeManager;
   KeyBindingManager get aceKeysManager;
   ws.Workspace get workspace;

--- a/ide/app/test/ace_test.dart
+++ b/ide/app/test/ace_test.dart
@@ -17,17 +17,17 @@ defineTests() {
   group('ace', () {
     // This essentially tests that the ace codebase is available.
     test('is available', () {
-      expect(AceContainer.available, true);
+      expect(AceManager.available, true);
     });
   });
 }
 
-class MockAceContainer implements AceContainer {
+class MockAceManager implements AceManager {
   /// The element to put the editor in.
   final Element parentElement = null;
   workspace.File currentFile = null;
 
-  MockAceContainer();
+  MockAceManager();
 
   EditSession createEditSession(String text, String fileName) {
     return new MockEditSession(fileName);
@@ -48,13 +48,13 @@ class MockAceContainer implements AceContainer {
   void clearMarkers() { }
 }
 
-class MockAceEditor implements AceEditor {
-  AceContainer aceContainer;
+class MockAceEditor implements TextEditor {
+  AceManager aceManager;
   workspace.File file;
 
-  MockAceEditor([this.aceContainer]);
+  MockAceEditor([this.aceManager]);
 
-  Element get element => aceContainer.parentElement;
+  Element get element => aceManager.parentElement;
 
   void activate() { }
   void resize() { }

--- a/ide/app/test/editors_test.dart
+++ b/ide/app/test/editors_test.dart
@@ -5,6 +5,7 @@
 library spark.editors_test;
 
 import 'dart:async';
+
 import 'package:unittest/unittest.dart';
 
 import 'ace_test.dart';
@@ -19,10 +20,10 @@ defineTests() {
   group('editors', () {
     test('general test', () {
       Workspace workspace = new Workspace();
-      AceContainer aceContainer = new MockAceContainer();
+      AceManager aceManager = new MockAceManager();
       PreferenceStore store = new MapPreferencesStore();
       EditorManager manager = new EditorManager(
-          workspace, aceContainer, store, new EventBus());
+          workspace, aceManager, store, new EventBus());
 
       MockFileSystem fs = new MockFileSystem();
 


### PR DESCRIPTION
A rename-only refactoring change:
- `AceEditor` ==> `TextEditor`
- `AceContainer` ==> `AceManager`

We had some overloaded names (including ace.Editor and ace.AceEditor) - I think this will help clarify things a bit.

@dinhviethoa @keertip 
