### PR TITLE
change our version dependency on ace

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -6,7 +6,7 @@ description: A Chrome app based development environment.
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
-  ace: '>=0.1.6'
+  ace: '>=0.1.7 <0.2.0'
   analyzer: '>=0.10.1 <0.11.0'
   archive: 1.0.6
   bootjack: any


### PR DESCRIPTION
Fix our version dependency on ace to below 0.2.0 - breaking changes are a-coming.

From https://github.com/rmsmith/ace.dart/pull/26, we'll need to make small changes to how we set and get annotations, and in-line the mode map into the `app/lib/ace.dart` file.

TRB, @umop 
