### PR TITLE
change from using chrome_gen to chrome

### DIFF
--- a/ide/app/lib/analyzer.dart
+++ b/ide/app/lib/analyzer.dart
@@ -17,7 +17,7 @@ import 'package:analyzer/src/generated/parser.dart';
 import 'package:analyzer/src/generated/scanner.dart';
 import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:path/path.dart' as path;
 
 import 'sdk.dart' as spark;

--- a/ide/app/lib/compiler.dart
+++ b/ide/app/lib/compiler.dart
@@ -49,7 +49,7 @@ class Compiler {
     return new Future.value(new CompilerResult._());
   }
 
-  Future<CompilerResult> compile(/*chrome_gen.FileEntry*/ entry) {
+  Future<CompilerResult> compile(/*chrome.FileEntry*/ entry) {
     // TODO: implement
 
     return new Future.value(new CompilerResult._());

--- a/ide/app/lib/git/commands/branch.dart
+++ b/ide/app/lib/git/commands/branch.dart
@@ -6,7 +6,7 @@ library git.commands.branch;
 
 import 'dart:async';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 import '../objectstore.dart';
 import '../options.dart';

--- a/ide/app/lib/git/commands/checkout.dart
+++ b/ide/app/lib/git/commands/checkout.dart
@@ -7,7 +7,7 @@ library git.commands.checkout;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 import '../constants.dart';
 import '../file_operations.dart';

--- a/ide/app/lib/git/commands/clone.dart
+++ b/ide/app/lib/git/commands/clone.dart
@@ -7,7 +7,7 @@ library git.commands.clone;
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:crypto/crypto.dart' as crypto;
 
 import '../file_operations.dart';

--- a/ide/app/lib/git/commands/commit.dart
+++ b/ide/app/lib/git/commands/commit.dart
@@ -7,7 +7,7 @@ library git.commands.commit;
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 import '../file_operations.dart';
 import '../object.dart';

--- a/ide/app/lib/git/commands/conditions.dart
+++ b/ide/app/lib/git/commands/conditions.dart
@@ -6,7 +6,7 @@ library git.commands.utils;
 
 import 'dart:async';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 import '../objectstore.dart';
 

--- a/ide/app/lib/git/commands/pull.dart
+++ b/ide/app/lib/git/commands/pull.dart
@@ -7,7 +7,7 @@ library git.commands.pull;
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:crypto/crypto.dart' as crypto;
 
 import '../file_operations.dart';

--- a/ide/app/lib/git/file_operations.dart
+++ b/ide/app/lib/git/file_operations.dart
@@ -9,13 +9,13 @@ import 'dart:core';
 import 'dart:js';
 import 'dart:typed_data';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 /**
  * Utility class to access HTML5 filesystem operations.
- * TODO(grv): Add unittests.
  *
- **/
+ * TODO(grv): Add unittests.
+ */
 abstract class FileOps {
 
   /**

--- a/ide/app/lib/git/git.dart
+++ b/ide/app/lib/git/git.dart
@@ -7,8 +7,8 @@ library git;
 import 'dart:async';
 import 'dart:js' as js;
 
-import 'package:chrome_gen/src/files.dart' as chrome_files;
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/src/files.dart' as chrome_files;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 import 'options.dart';
 

--- a/ide/app/lib/git/http_fetcher.dart
+++ b/ide/app/lib/git/http_fetcher.dart
@@ -10,7 +10,7 @@ import 'dart:core';
 import 'dart:html';
 import 'dart:typed_data';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 import 'objectstore.dart';
 import 'upload_pack_parser.dart';

--- a/ide/app/lib/git/object.dart
+++ b/ide/app/lib/git/object.dart
@@ -8,7 +8,7 @@ import 'dart:convert';
 import 'dart:core';
 import 'dart:typed_data';
 
-import 'package:chrome_gen/src/common_exp.dart' as chrome;
+import 'package:chrome/src/common_exp.dart' as chrome;
 
 import 'object_utils.dart';
 
@@ -16,7 +16,7 @@ import 'object_utils.dart';
  * Encapsulates a Gitobject
  *
  * TODO(grv): Add unittests.
- **/
+ */
 abstract class GitObject {
 
   /**

--- a/ide/app/lib/git/object_utils.dart
+++ b/ide/app/lib/git/object_utils.dart
@@ -7,7 +7,7 @@ library git.objects.utils;
 import 'dart:async';
 import 'dart:core';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 import 'file_operations.dart';
 import 'object.dart';

--- a/ide/app/lib/git/objectstore.dart
+++ b/ide/app/lib/git/objectstore.dart
@@ -11,7 +11,7 @@ import 'dart:html';
 import 'dart:js';
 import 'dart:typed_data';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:crypto/crypto.dart' as crypto;
 
 import 'file_operations.dart';
@@ -25,9 +25,9 @@ import 'zlib.dart';
 
 /**
  * An objectstore for git objects.
+ *
  * TODO(grv): Add unittests, add better docs.
- **/
-
+ */
 class GitRef {
   String sha;
   String name;
@@ -37,7 +37,6 @@ class GitRef {
   dynamic remote;
 
   GitRef(this.sha, this.name, [this.type, this.remote]);
-
 }
 
 class GitConfig {

--- a/ide/app/lib/git/zlib.dart
+++ b/ide/app/lib/git/zlib.dart
@@ -6,7 +6,7 @@ library git.zlib;
 
 import 'dart:js' as js;
 
-import 'package:chrome_gen/src/common_exp.dart' as chrome;
+import 'package:chrome/src/common_exp.dart' as chrome;
 
 /**
  * Encapsulates the result returned by js zlib library.

--- a/ide/app/lib/preferences.dart
+++ b/ide/app/lib/preferences.dart
@@ -13,7 +13,7 @@ library spark.preferences;
 
 import 'dart:async';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 /**
  * A PreferenceStore backed by `chome.storage.local`.

--- a/ide/app/lib/sdk.dart
+++ b/ide/app/lib/sdk.dart
@@ -20,7 +20,7 @@ import 'dart:convert';
 import 'dart:html' as html;
 import 'dart:typed_data' as typed_data;
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 /**
  * Return the contents of the file at the given path. The path is relative to

--- a/ide/app/lib/tcp.dart
+++ b/ide/app/lib/tcp.dart
@@ -9,20 +9,20 @@
  * See also:
  *
  * * [developer.chrome.com/apps/socket.html](http://developer.chrome.com/apps/socket.html)
- * * [dart-gde.github.io/chrome_gen.dart/app/chrome.socket.html](http://dart-gde.github.io/chrome_gen.dart/app/chrome.socket.html)
+ * * [dart-gde.github.io/chrome.dart/app/chrome.socket.html](http://dart-gde.github.io/chrome.dart/app/chrome.socket.html)
  */
 library spark.tcp;
 
 import 'dart:async';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
-export 'package:chrome_gen/chrome_app.dart' show SocketInfo;
+import 'package:chrome/chrome_app.dart' as chrome;
+export 'package:chrome/chrome_app.dart' show SocketInfo;
 
 const LOCAL_HOST = '127.0.0.1';
 
 // TODO(devoncarew): these classes are fairly generic; explore contributing them
-// to package:chrome_gen, or to a new utility library for chrome functionalty
-// built on chrome_gen? chrome_util?
+// to package:chrome, or to a new utility library for chrome functionalty
+// built on chrome? chrome_util?
 
 /**
  * An [Exception] implementation for socket errors.

--- a/ide/app/lib/tests.dart
+++ b/ide/app/lib/tests.dart
@@ -7,7 +7,7 @@ library spark.tests;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:logging/logging.dart';
 import 'package:unittest/unittest.dart' as unittest;
 

--- a/ide/app/lib/ui/widgets/imageviewer.dart
+++ b/ide/app/lib/ui/widgets/imageviewer.dart
@@ -10,9 +10,11 @@ library spark.editors.image;
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:math' as math;
+
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:crypto/crypto.dart' show CryptoUtils;
-import 'package:chrome_gen/chrome_app.dart' as chrome;
 import 'package:mime/mime.dart' as mime;
+
 import '../utils/html_utils.dart';
 import '../../workspace.dart';
 

--- a/ide/app/lib/utils.dart
+++ b/ide/app/lib/utils.dart
@@ -6,7 +6,7 @@ library spark.utils;
 
 import 'dart:web_audio';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 
 /**
  * This method is shorthand for [chrome.i18n.getMessage].

--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -12,7 +12,7 @@ import 'dart:collection';
 import 'dart:convert' show JSON;
 import 'dart:math' as math;
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:logging/logging.dart';
 
 import 'preferences.dart';

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -9,9 +9,9 @@ import 'dart:convert' show JSON;
 import 'dart:html';
 
 import 'package:bootjack/bootjack.dart' as bootjack;
-import 'package:chrome_gen/chrome_app.dart' as chrome;
-import 'package:logging/logging.dart';
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:dquery/dquery.dart';
+import 'package:logging/logging.dart';
 
 import 'lib/ace.dart';
 import 'lib/actions.dart';

--- a/ide/app/test/files_mock.dart
+++ b/ide/app/test/files_mock.dart
@@ -10,11 +10,11 @@ library spark.files_mock;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:chrome_gen/chrome_app.dart';
+import 'package:chrome/chrome_app.dart';
 import 'package:mime/mime.dart' as mime;
 import 'package:path/path.dart' as path;
 
-export 'package:chrome_gen/chrome_app.dart'
+export 'package:chrome/chrome_app.dart'
   show FileEntry, DirectoryEntry, ChromeFileEntry;
 
 /**

--- a/ide/app/test/files_test.dart
+++ b/ide/app/test/files_test.dart
@@ -4,7 +4,7 @@
 
 library spark.files_test;
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:unittest/unittest.dart';
 
 import 'files_mock.dart';

--- a/ide/app/test/git/objectstore_test.dart
+++ b/ide/app/test/git/objectstore_test.dart
@@ -6,7 +6,7 @@ library spark.git_objectstore_test;
 
 import 'dart:async';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:unittest/unittest.dart';
 
 import '../../lib/git/file_operations.dart';

--- a/ide/app/test/git/pack_index_test.dart
+++ b/ide/app/test/git/pack_index_test.dart
@@ -8,7 +8,7 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'dart:convert';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:unittest/unittest.dart';
 
 import '../../lib/git/pack.dart';

--- a/ide/app/test/git/pack_test.dart
+++ b/ide/app/test/git/pack_test.dart
@@ -6,7 +6,7 @@ library git_pack_test;
 
 import 'dart:typed_data';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:unittest/unittest.dart';
 
 import '../../lib/git/pack.dart';

--- a/ide/app/test/preferences_test.dart
+++ b/ide/app/test/preferences_test.dart
@@ -6,7 +6,7 @@ library preferences_test;
 
 import 'dart:async';
 
-//import 'package:chrome_gen/chrome_app.dart' as chrome;
+//import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:unittest/unittest.dart';
 
 import '../lib/preferences.dart';

--- a/ide/app/test/workspace_test.dart
+++ b/ide/app/test/workspace_test.dart
@@ -6,7 +6,7 @@ library spark.workspace_test;
 
 import 'dart:async';
 
-import 'package:chrome_gen/chrome_app.dart' as chrome;
+import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:unittest/unittest.dart';
 
 import 'files_mock.dart';

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   archive: 1.0.6
   bootjack: any
   browser: any
-  chrome_gen: '>=0.3.2 <0.4.0'
+  chrome: '>=0.4.0 <0.5.0'
   crypto: any
   dquery: 0.5.3+7
   intl: any


### PR DESCRIPTION
Move to using the `package:chrome` library from `package:chrome_gen`. All the content of chrome_gen has been moved into chrome; `chrome_gen` is now deprecated and `chrome` is the new system-of-record, where bug-fixing will occur and new features will show up.

https://github.com/dart-gde/chrome.dart

@dinhviethoa for review

@financeCoding for FYI
