### PR TITLE
Improved highlight of the treeview

### DIFF
--- a/ide/app/lib/ui/files_controller.dart
+++ b/ide/app/lib/ui/files_controller.dart
@@ -652,6 +652,8 @@ class FilesController implements TreeViewDelegate {
       // to close the dropdown. For example dropdown.toggle() won't work.
       menuContainer.classes.remove('open');
       cancelEvent(event);
+
+      _treeView.focus();
     }
 
     // When the user clicks outside the menu, we'll close it.

--- a/ide/app/lib/ui/widgets/listview.css
+++ b/ide/app/lib/ui/widgets/listview.css
@@ -1,3 +1,7 @@
 .listview-cell-highlighted {
   background-color: #ddf;
 }
+
+.listview-container:focus .listview-cell-highlighted {
+  background-color: #aaf;
+}

--- a/ide/app/lib/ui/widgets/listview.dart
+++ b/ide/app/lib/ui/widgets/listview.dart
@@ -197,7 +197,7 @@ class ListView {
    */
   void _onClicked(int rowIndex, Event event) {
     _extendedSelectionRow = -1;
-    _container.focus();
+    focus();
 
     if (!_delegate.listViewRowClicked(event, rowIndex)) {
       // If listViewRowClicked returns false, don't handle.
@@ -414,6 +414,13 @@ class ListView {
 
   ListViewCell cellForRow(int rowIndex) {
     return _rows[rowIndex].cell;
+  }
+
+  /**
+   * This method will focus the list view.
+   */
+  void focus() {
+    _container.focus();
   }
 
   bool get dropEnabled => _dropEnabled;

--- a/ide/app/lib/ui/widgets/treeview.dart
+++ b/ide/app/lib/ui/widgets/treeview.dart
@@ -470,4 +470,12 @@ class TreeView implements ListViewDelegate {
   TreeViewDragImage privateDragImage(MouseEvent event) {
     return _delegate.treeViewDragImage(this, selection, event);
   }
+
+  /**
+   * This method will focus the tree view. The key input will be handled by
+   * the tree view once the list view has the focus.
+   */
+  void focus() {
+    _listView.focus();
+  }
 }

--- a/ide/app/spark_polymer_ui.css
+++ b/ide/app/spark_polymer_ui.css
@@ -93,6 +93,7 @@ https://code.google.com/p/dart/issues/detail?id=14382 is fixed
 #fileViewArea .listview-container {
   bottom: 0;
   left: 0;
+  outline: 0;
   overflow-x: auto;
   overflow-y: auto;
   position: absolute;


### PR DESCRIPTION
The selection highlight in the list view will have a darker color when the treeview is focused.
I got rid of the blue focus ring.

Additional change: when the context menu is closed, the focus is back on the treeview.

@devoncarew @umop
