### PR TITLE
peg the version of cipher that we use

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -8,10 +8,11 @@ environment:
 dependencies:
   ace: '>=0.1.7 <0.2.0'
   analyzer: '>=0.10.1 <0.11.0'
-  archive: 1.0.6
+  archive: 1.0.8
   bootjack: any
   browser: any
   chrome: '>=0.4.0 <0.5.0'
+  cipher: '>=0.4.0 <0.5.0'
   crypto: any
   dquery: 0.5.3+7
   intl: any


### PR DESCRIPTION
TBR - peg the version of cipher that we use. The latest version (0.5.0) has a dependency on `dart:io`.
