### PR TITLE
Fix for walkFiles

### DIFF
--- a/ide/app/lib/git/commands/commit.dart
+++ b/ide/app/lib/git/commands/commit.dart
@@ -41,7 +41,8 @@ class Commit {
         }
 
         if (entry.isDirectory) {
-          return walkFiles(entry as DirectoryEntry, store).then((String sha) {
+          return walkFiles(entry as chrome.DirectoryEntry, store).then(
+              (String sha) {
             if (sha != null) {
               treeEntries.add(new TreeEntry(entry.name, shaToBytes(sha),
                   false));


### PR DESCRIPTION
(entry as chrome.ChromeFileEntry) does not work if entry is a chrome.DirectoryEntry, however the opposite does work.

[i.e. the following is able to commit without error, the previous code could not showing a type cast error.]

[ping: @gaurave]
