### PR TITLE
Devoncarew git stateful

### DIFF
--- a/ide/app/lib/scm.dart
+++ b/ide/app/lib/scm.dart
@@ -128,6 +128,12 @@ class GitScmProvider extends ScmProvider {
 
     return _operations[project];
   }
+
+  // TODO: remove this
+  void createMetaDataFor(Project project, ObjectStore store) {
+    GitScmProjectOperations operations = getOperationsFor(project);
+    operations._objectStore = store;
+  }
 }
 
 /**
@@ -138,6 +144,8 @@ class GitScmProjectOperations extends ScmProjectOperations {
 
   GitScmProjectOperations(ScmProvider provider, Project project) :
     super(provider, project) {
+
+    // TODO: This ctor of ObjectStore does not properly populate the git metadata.
     _objectStore = new ObjectStore(project.entry);
   }
 

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -1274,10 +1274,13 @@ class GitCheckoutAction extends SparkActionWithDialog implements ContextAction {
     store.getCurrentBranch().then((String currentBranch) {
       (getElement('#currentBranchName') as InputElement).value = currentBranch;
 
+      _branchSelectElement.length = 0;
+
       store.getLocalBranches().then((List<String> branches) {
         branches.sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
         for (String branchName in branches) {
-          _branchSelectElement.append(new OptionElement(data: branchName, value: branchName));
+          _branchSelectElement.append(
+              new OptionElement(data: branchName, value: branchName));
         }
       });
 
@@ -1326,6 +1329,12 @@ class _GitCloneJob extends Job {
       return options.store.init().then((_) {
         return clone.clone().then((_) {
           return spark.workspace.link(dir).then((folder) {
+            // TODO: We're explicitly having to push this specific instance of
+            // the object store into the project's scm metadata. This shouldn't
+            // be necessary.
+            scm.GitScmProvider gitScmProvider = scm.getProviderType('git');
+            gitScmProvider.createMetaDataFor(folder, options.store);
+
             Timer.run(() {
               spark._filesController.selectFile(folder);
               spark._filesController.setFolderExpanded(folder);


### PR DESCRIPTION
- changed spark.dart to not maintain state about what is the current git ObjectStore; the scm provider can now return the correct objectstore for a given project
- fixed an issue with the git checkout dialog
- found an issue, that ObjectStore that are not populated via a clone are not fully functional. I.e., in the next spark session some git operations will not work

@gaurave 
