### PR TITLE
Close menu when clicking outside (fixed #628)

### DIFF
--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -33,3 +33,13 @@ body {
   opacity: 0.6;
   z-index: 500;
 }
+
+#menuBackdrop {
+  display:none;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  z-index: 500;
+}

--- a/ide/app/spark_polymer.html
+++ b/ide/app/spark_polymer.html
@@ -58,6 +58,7 @@
   <spark-polymer-ui id="topUi"></spark-polymer-ui>
   <!-- app_modal used to make app appear modal. -->
   <div id="modalBackdrop"></div>
+  <div id="menuBackdrop"></div>
 </body>
 
 </html>

--- a/widgets/lib/spark_menu_button/spark_menu_button.dart
+++ b/widgets/lib/spark_menu_button/spark_menu_button.dart
@@ -5,6 +5,7 @@
 library spark_widgets.menu_button;
 
 import 'package:polymer/polymer.dart';
+import 'dart:html';
 
 import '../common/spark_widget.dart';
 import '../spark_menu/spark_menu.dart';
@@ -23,6 +24,7 @@ class SparkMenuButton extends SparkWidget {
   @published bool responsive = false;
   @published String valign = "center";
   @published String selectedClass = "";
+  var subscription = null;
 
   SparkMenuButton.created(): super.created();
 
@@ -30,13 +32,29 @@ class SparkMenuButton extends SparkWidget {
   void toggle() {
     ($['overlayMenu'] as SparkMenu).clearSelection();
     opened = !opened;
-
+    var appModal = querySelector("#menuBackdrop");
+    if (appModal != null) {
+      appModal.style.display = opened ? "block" : "none";
+      if (opened) {
+        assert(subscription == null);
+        subscription = appModal.onClick.listen((e) {
+          toggle();
+        });
+      } else if (subscription != null) {
+        subscription.cancel();
+        subscription = null;
+      }
+    }
     // TODO(ussuri): This is a temporary plug to make spark-overlay see changes
     // in 'opened' when run as deployed code. Just binding via {{opened}} alone
     // isn't detected and the menu doesn't open.
     if (IS_DART2JS) {
       ($['overlay'] as SparkOverlay).opened = opened;
     }
+  }
+
+  void onClickOutsideMenu() {
+    toggle();
   }
 
   //* Returns the selected item.


### PR DESCRIPTION
- Adds a backdrop that is clickable
- When this backdrop is clicked, the menu is closed.

SparkMenuButton will rely on existence of that backdrop to implement that feature.

@ussuri
