### PR TITLE
Realign menu arrow with button + eliminate overlap between them

### DIFF
--- a/ide/app/spark_polymer_ui.css
+++ b/ide/app/spark_polymer_ui.css
@@ -270,3 +270,7 @@ spark-menu-item:hover .menu-button {
   color: #3a84c3;
   text-decoration: none;
 }
+
+#toolbarRight {
+  padding-right: 16px;
+}

--- a/widgets/lib/spark_menu_button/spark_menu_button.css
+++ b/widgets/lib/spark_menu_button/spark_menu_button.css
@@ -19,7 +19,8 @@ spark-button button {
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 3px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  margin-left: 8px;
+  margin-left: 14px;
+  margin-top: 8px;
   -webkit-transform: translateX(-50%);
   transform: translateX(-50%);
 }
@@ -41,11 +42,13 @@ spark-button button {
   border-color: transparent transparent #cfcfcf transparent;
   border-style: solid;
   border-width: 8px;
+  cursor: pointer;
 }
 
 .arrow-inner {
   border-bottom-color: white;
   margin-top: -15px;
+  top: 1px;
 }
 
 [valign=right] .arrow {

--- a/widgets/lib/spark_menu_button/spark_menu_button.html
+++ b/widgets/lib/spark_menu_button/spark_menu_button.html
@@ -38,7 +38,7 @@
       <spark-overlay id="overlay" class="slideup" opened="{{opened}}" modal
           autoCloseDisabled on-activate="{{toggle}}">
         <div class="arrow"></div>
-        <div class="arrow arrow-inner"></div>
+        <div class="arrow arrow-inner" on-click="{{toggle}}"></div>
         <spark-menu id="overlayMenu"
             selected="{{selected}}"
             valueattr="{{valueattr}}">


### PR DESCRIPTION
@terrylucas @dinhviethoa

Combining fixes provided by @terrylucas and mine to fix the menu styling (hopefully for good now).

![screenshot from 2014-01-17 16 17 56](https://f.cloud.github.com/assets/5606182/1945717/0cccb838-7fd6-11e3-8ddf-3592a9038896.png)
