### PR TITLE
Two small changes to increase library "utility"

### DIFF
--- a/ide/app/lib/git/object.dart
+++ b/ide/app/lib/git/object.dart
@@ -222,6 +222,20 @@ class CommitObject extends GitObject {
     str += _message;
     return str;
   }
+
+  /**
+   * Returns the commit object as a map for easy advanced formatting instead
+   * of toString().
+   */
+  Map<String, String> toMap() {
+    return {
+            "commit": _sha,
+            "author_name": author.name,
+            "author_email": author.email,
+            "date": author.date.toString(),
+            "message": _message
+           };
+  }
 }
 
 /**

--- a/ide/app/lib/git/objectstore.dart
+++ b/ide/app/lib/git/objectstore.dart
@@ -253,7 +253,7 @@ class ObjectStore {
   }
 
 
-  Future<CommitGraph> getCommitGraph(List<String> headShas, int limit) {
+  Future<CommitGraph> getCommitGraph(List<String> headShas, [int limit]) {
     List<CommitObject> commits = [];
     Map<String, bool> seen = {};
 
@@ -283,7 +283,8 @@ class ObjectStore {
           return null;
       }).then((_) {
 
-        if (commits.length >= limit || nextLevel.length == 0) {
+        if ((limit != null && commits.length >= limit) ||
+            nextLevel.length == 0) {
           return new Future.value(new CommitGraph(commits, nextLevel));
         } else {
           return walkLevel(nextLevel);

--- a/ide/app/lib/git/objectstore.dart
+++ b/ide/app/lib/git/objectstore.dart
@@ -281,15 +281,14 @@ class ObjectStore {
           }
 
           return null;
-      }).then((_) {
-
-        if ((limit != null && commits.length >= limit) ||
-            nextLevel.length == 0) {
-          return new Future.value(new CommitGraph(commits, nextLevel));
-        } else {
-          return walkLevel(nextLevel);
-        }
-      });
+        }).then((_) {
+          if ((limit != null && commits.length >= limit) ||
+              nextLevel.length == 0) {
+            return new Future.value(new CommitGraph(commits, nextLevel));
+          } else {
+            return walkLevel(nextLevel);
+          }
+        });
       });
     }
     return walkLevel(headShas).then((_) => new CommitGraph(commits, []));


### PR DESCRIPTION
(@gaurave)

--> toMap() in CommitObject returns a map with the fields normally output in toString() --> this is a nicer way to be able to access and format the CommitObject when printing in "git log" (currently have to use split('\n') with a bunch of if/else to highlight lines, indent etc).

--> getCommitGraph changing limit to an optional parameter to allow the git log default behaviour (given no paging) of listing all commits under the headSha. Also fixed minor indenting.
This should result in no behavioral changes for existing code.
