### PR TITLE
Use more correct boudning rectangle in SparkOverlay.pointInOverlay() + nits

### DIFF
--- a/widgets/lib/spark_modal/spark_modal.dart
+++ b/widgets/lib/spark_modal/spark_modal.dart
@@ -17,7 +17,7 @@ class SparkModal extends SparkOverlay {
 
   @override
   void captureHandler(MouseEvent e) {
-    if (!pointInOverlay(this, e.client)) {
+    if (!isPointInOverlay(e.client)) {
       e.stopImmediatePropagation();
       e.preventDefault();
     }

--- a/widgets/lib/spark_overlay/spark_overlay.dart
+++ b/widgets/lib/spark_overlay/spark_overlay.dart
@@ -230,7 +230,7 @@ class SparkOverlay extends SparkWidget {
   // scrim.
   void captureHandler(MouseEvent e) {
     // TODO(terry): Hack to work around lightdom or event.path not yet working.
-    if (!autoCloseDisabled && !pointInOverlay(this, e.client)) {
+    if (!autoCloseDisabled && !isPointInOverlay(e.client)) {
       // TODO(terry): How to cancel the event e.cancelable = true;
       e.stopImmediatePropagation();
       e.preventDefault();
@@ -239,8 +239,8 @@ class SparkOverlay extends SparkWidget {
     }
   }
 
-  bool pointInOverlay(SparkOverlay overlay, Point xyGlobal) {
-    return overlay.offset.containsPoint(xyGlobal);
+  bool isPointInOverlay(Point xyGlobal) {
+    return super.getBoundingClientRect().containsPoint(xyGlobal);
   }
 
   void keydownHandler(KeyboardEvent e) {


### PR DESCRIPTION
TBR: @terrylucas

In particular, this fixes the problem where a click on a <button> or other plain HTML element in spark-overlay would close it (with autoCloseDisabled == false), such as the now-gone + and - buttons to switch themes and shortcuts.
