### PR TITLE
Re-enable menu auto-closing now that some obstacles to that have been fixed

### DIFF
--- a/widgets/lib/spark_menu_button/spark_menu_button.dart
+++ b/widgets/lib/spark_menu_button/spark_menu_button.dart
@@ -4,6 +4,8 @@
 
 library spark_widgets.menu_button;
 
+import 'dart:html';
+
 import 'package:polymer/polymer.dart';
 
 import '../common/spark_widget.dart';
@@ -36,6 +38,15 @@ class SparkMenuButton extends SparkWidget {
     // isn't detected and the menu doesn't open.
     if (IS_DART2JS) {
       ($['overlay'] as SparkOverlay).opened = opened;
+    }
+  }
+
+  //* Handle the on-opened event from the dropdown. It will be fired e.g. when
+  //* mouse is clicked outside the dropdown (with autoClosedDisabled == false).
+  void onOpened(CustomEvent e) {
+    // Autoclosing is the only event we're interested in.
+    if (e.detail == false) {
+      opened = false;
     }
   }
 

--- a/widgets/lib/spark_menu_button/spark_menu_button.html
+++ b/widgets/lib/spark_menu_button/spark_menu_button.html
@@ -36,7 +36,7 @@
 
     <div responsive="{{responsive}}" valign="{{valign}}">
       <spark-overlay id="overlay" class="slideup" opened="{{opened}}" modal
-          autoCloseDisabled on-activate="{{toggle}}">
+          on-activate="{{toggle}}" on-opened="{{onOpened}}">
         <div class="arrow"></div>
         <div class="arrow arrow-inner" on-click="{{toggle}}"></div>
         <spark-menu id="overlayMenu"


### PR DESCRIPTION
@dinhviethoa

I've fixed some small issues with the built-in autoclosing capability of `<spark-overlay>` in #774 (which are anyway unimportant now that the +/- buttons are gone from the menu). With that, menu autoclosing is trivial to achieve with a few lines of code in spark_menu_button.*. I think this fix is simpler than #755, better utilizes the already available functionality, and avoids dependency of spark-menu-button on an external element with fixed name and z-index. It also doesn't block the UI, so buttons can be clicked or files in the treeview selected, for example.
