### PR TITLE
File search box in the toolbar

### DIFF
--- a/ide/app/lib/search.dart
+++ b/ide/app/lib/search.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark.search;
+
+import 'dart:async';
+
+import 'package:spark_widgets/spark_suggest/spark_suggest_box.dart';
+
+import 'workspace.dart';
+
+// TODO(yjbanov): Have to do this because SparkModel is not initialized at the
+//                time oracle is created. There should be a better way.
+typedef Workspace WsGetter();
+
+/// Callback invoked with the file user selected to open.
+typedef void FileOpener(File file);
+
+/// Provides search [Suggestion]s for the top-level search box.
+///
+/// Currently searches by file name only.
+class SearchOracle implements SuggestOracle {
+  final WsGetter _wsGetter;
+  final FileOpener _fileOpener;
+
+  SearchOracle(this._wsGetter, this._fileOpener);
+
+  Stream<List<Suggestion>> getSuggestions(String text) {
+    if (text == null || text.trim().isEmpty) {
+      return new Stream.fromIterable([[]]);
+    }
+    text = _cleanse(text);
+    // TODO(yjbanov): this is the most naive algorithm ever. We need a way to
+    //                index the sources and run the search incrementally and
+    //                preferably in a separate isolate, and test on a large
+    //                project.
+    var suggestions = _wsGetter().traverse()
+        .where((res) => res is File && _matches(res.name, text))
+        .map((res) => _makeSuggestionFromResource(res))
+        .take(20)
+        .toList(growable: false);
+    return new Stream.fromIterable([suggestions]);
+  }
+
+  String _cleanse(String s) => s
+      .trim()
+      .replaceAll('_', '')
+      .replaceAll('-', '')
+      .toLowerCase();
+
+  bool _matches(String string, String searchText) =>
+      string != null && _cleanse(string).contains(searchText);
+
+  Suggestion _makeSuggestionFromResource(Resource res) =>
+      new Suggestion('${res.name} (${res.parent.path})',
+          onSelected: () => _fileOpener(res));
+}

--- a/ide/app/spark_polymer_ui.css
+++ b/ide/app/spark_polymer_ui.css
@@ -10,11 +10,14 @@
 @import url("lib/ui/widgets/imageviewer.css");
 
 #saveStatus {
-  flex: 1;
   color: #aaa;
   margin-left: 6px;
   vertical-align: bottom;
   white-space: nowrap;
+}
+
+#searchBox {
+  flex: 1;
 }
 
 .fileview-filename-container {

--- a/ide/app/spark_polymer_ui.dart
+++ b/ide/app/spark_polymer_ui.dart
@@ -8,12 +8,22 @@ import 'dart:html';
 
 import 'package:polymer/polymer.dart';
 import 'package:spark_widgets/common/spark_widget.dart';
+import 'package:spark_widgets/spark_suggest/spark_suggest_box.dart';
 
 import 'spark_model.dart';
+import 'lib/search.dart';
 
 @CustomTag('spark-polymer-ui')
 class SparkPolymerUI extends SparkWidget {
-  SparkPolymerUI.created() : super.created();
+
+  @observable SuggestOracle searchOracle;
+
+  SparkPolymerUI.created() : super.created() {
+    searchOracle = new SearchOracle(
+        () => SparkModel.instance.workspace,
+        (f) => SparkModel.instance.editorArea.selectFile(
+            f, forceOpen: true, replaceCurrent: false, switchesTab: true));
+  }
 
   void buildTestMenu() {
     var menu = getShadowDomElement('#mainMenu');

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -14,6 +14,8 @@
 <link rel="import" href="packages/spark_widgets/spark_overlay/spark_overlay.html">
 <link rel="import" href="packages/spark_widgets/spark_splitter/spark_splitter.html">
 <link rel="import" href="packages/spark_widgets/spark_status/spark_status.html">
+<link rel="import" href="packages/spark_widgets/spark_suggest/spark_suggest_box.html">
+<link rel="import" href="packages/spark_widgets/spark_suggest/spark_suggest_list.html">
 <link rel="import" href="packages/spark_widgets/spark_toolbar/spark_toolbar.html">
 
 <!--link rel="import" href="packages/polymer_elements/polymer_flex_layout/polymer_flex_panel.html"-->
@@ -35,6 +37,10 @@
       <spark-status id="sparkStatus"></spark-status>
 
       <span id="saveStatus" class="titleFont"></span>
+
+      <spark-suggest-box id="searchBox" oracle="{{searchOracle}}"
+          placeholder="Search...">
+      </spark-suggest-box>
 
       <div id="toolbarRight" class="titleFont">
         <spark-menu-button id="mainMenu"

--- a/ide/app/test/all.dart
+++ b/ide/app/test/all.dart
@@ -22,6 +22,7 @@ import 'git/all.dart' as git_all_test;
 import 'preferences_test.dart' as preferences_test;
 import 'scm_test.dart' as scm_test;
 import 'sdk_test.dart' as sdk_test;
+import 'search_test.dart' as search_test;
 import 'server_test.dart' as server_test;
 import 'tcp_test.dart' as tcp_test;
 import 'utils_test.dart' as utils_test;
@@ -46,6 +47,7 @@ void defineTests() {
   preferences_test.defineTests();
   scm_test.defineTests();
   sdk_test.defineTests();
+  search_test.defineTests();
   server_test.defineTests();
   tcp_test.defineTests();
   utils_test.defineTests();

--- a/ide/app/test/search_test.dart
+++ b/ide/app/test/search_test.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark.search_test;
+
+import 'dart:async';
+
+import 'package:unittest/unittest.dart';
+
+import '../lib/search.dart';
+import '../lib/workspace.dart';
+import 'files_mock.dart';
+
+defineTests() {
+  group('SearchOracle', () {
+    MockFileSystem fs;
+    Workspace ws;
+    DirectoryEntry rootDir;
+    SearchOracle oracle;
+
+    setUp(() {
+      fs = new MockFileSystem();
+      ws = new Workspace();
+      rootDir = fs.createDirectory('/root');
+      [
+       '/root/Spark.DART',  // mixed-case on purpose
+       '/root/rocks.dart',
+       '/root/multi1.dart',
+       '/root/multi2.dart',
+       '/root/i_has-underdashes.txt',
+      ].forEach(fs.createFile);
+      oracle = new SearchOracle(
+          () => ws,
+          (f) { fail('Should not have reached this line'); });
+    });
+
+    whenReady(test()) => () => ws.link(rootDir).then((_) => test());
+
+    test('should find single matching file', whenReady(() {
+      oracle.getSuggestions('spark').listen(expectAsync1((list) {
+        expect(list, hasLength(1));
+        expect(list[0].displayLabel, 'Spark.DART (/root)');
+      }));
+    }));
+
+    test('should find all matching files', whenReady(() {
+      oracle.getSuggestions('multi').listen(expectAsync1((list) {
+        expect(list, hasLength(2));
+        expect(list[0].displayLabel, 'multi1.dart (/root)');
+        expect(list[1].displayLabel, 'multi2.dart (/root)');
+      }));
+    }));
+
+    test('should ignore case', whenReady(() {
+      oracle.getSuggestions('SP').listen(expectAsync1((list) {
+        expect(list, hasLength(1));
+        expect(list[0].displayLabel, 'Spark.DART (/root)');
+      }));
+    }));
+
+    test('should ignore underscores', whenReady(() {
+      oracle.getSuggestions('ih-asunder_dashes').listen(expectAsync1((list) {
+        expect(list, hasLength(1));
+        expect(list[0].displayLabel, 'i_has-underdashes.txt (/root)');
+      }));
+    }));
+
+    test('should not return non-matching suggestions', whenReady(() {
+      oracle.getSuggestions('does_not_match').listen(expectAsync1((list) {
+        expect(list, hasLength(0));
+      }));
+    }));
+
+    test('should not return anything on empty/null text', whenReady(() {
+      oracle.getSuggestions('').listen(expectAsync1((list) {
+        expect(list, hasLength(0));
+      }));
+      oracle.getSuggestions(null).listen(expectAsync1((list) {
+        expect(list, hasLength(0));
+      }));
+    }));
+  });
+}

--- a/widgets/lib/common/spark_widget.dart
+++ b/widgets/lib/common/spark_widget.dart
@@ -16,6 +16,12 @@ class SparkWidget extends PolymerElement {
   static const CSS_ENABLED = "enabled";
   static const CSS_DISABLED = "disabled";
 
+  // Popular key codes
+  static const DOWN_KEY = 40;
+  static const UP_KEY = 38;
+  static const ENTER_KEY = 13;
+  static const ESCAPE_KEY = 27;
+
   SparkWidget.created() : super.created();
 
   @override

--- a/widgets/lib/spark_suggest/spark_suggest_box.css
+++ b/widgets/lib/spark_suggest/spark_suggest_box.css
@@ -1,0 +1,66 @@
+/* Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details. */
+/* All rights reserved.  Use of this source code is governed by a BSD-style */
+/* license that can be found in the LICENSE file. */
+
+#text-box {
+  outline: none;
+  border-radius: 12px;
+  border: 1px solid #cccccc;
+  padding: 2px 3px 2px 0px;
+  width: 100%;
+  font-size: 14px;
+}
+
+#text-box:focus {
+  border-color: #aaaaaa;
+}
+
+.suggest-item-list {
+  padding: 5px 0;
+}
+
+.suggest-item {
+  padding: 7px 20px;
+  font-size: 14px;
+}
+
+[highlighted=true].suggest-item {
+  background-color: #3a84c3;
+  color: white;
+}
+
+#loading-indicator {
+    position: relative;
+    height: 3px;
+    overflow: hidden;
+}
+
+#r0 {
+    position: absolute;
+    height: 100%;
+    width: 200%;
+    -webkit-animation-duration: 2s;
+    -webkit-animation-name: move;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-timing-function: linear;
+}
+
+@-webkit-keyframes move {
+    from {
+        left: -100%;
+    }
+    to {
+        left: 0;
+    }
+}
+
+#r1,#r2,#r3,#r4,#r5,#r6,#r7,#r8 {
+    height: 100%;
+    width: 12.5%;
+    float: left;
+}
+
+#r1,#r5 { background-color: #166bec; }
+#r2,#r6 { background-color: #d94530; }
+#r3,#r7 { background-color: #019d5a; }
+#r4,#r8 { background-color: #ffba03; }

--- a/widgets/lib/spark_suggest/spark_suggest_box.dart
+++ b/widgets/lib/spark_suggest/spark_suggest_box.dart
@@ -1,0 +1,154 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark_widgets.suggest;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:polymer/polymer.dart';
+
+import '../common/spark_widget.dart';
+
+/**
+ * A single suggestion supplied by a [SuggestOracle]. Provides a [displayLabel]
+ * and an [onSelected] callback. [onSelected] is called when the user chooses
+ * `this` suggestion.
+ */
+class Suggestion {
+  final String displayLabel;
+  final Function onSelected;
+
+  Suggestion(this.displayLabel, {this.onSelected});
+}
+
+/**
+ * Source suggestions for spark-suggest-box. Implemented and supplied by the
+ * component implementing a concrete suggest box.
+ */
+abstract class SuggestOracle {
+  /**
+   * [SparkSuggestBox] will call this method with [text] entered by user and
+   * listen on returned [Stream] for suggestions. The stream may return
+   * suggestions multiple times. This way if the suggestions are coming from
+   * multiple sources they can be supplied incrementally. While the stream is
+   * open the suggest-box will show a loading indicator as a cue for the user
+   * that more suggestions may be received. It is up to the implementor to
+   * close the stream after delivering all suggestions.
+   */
+  Stream<List<Suggestion>> getSuggestions(String text);
+}
+
+/**
+ * A suggest component. See docs in `spark_suggest_box.html`.
+ */
+@CustomTag("spark-suggest-box")
+class SparkSuggestBox extends SparkWidget {
+  /// Text shown when the text box is empty.
+  @published String placeholder;
+  /// Provies suggestions for `this` suggest box.
+  @published SuggestOracle oracle;
+  /// Currently displayed suggestions.
+  @observable final suggestions = new ObservableList();
+  /// Currently highlighted (but not yet selected) suggestion
+  @observable int selectionIndex = -1;
+  /// Whether we're loading suggestions. `true` as long as we're subscribed to
+  /// the [oracle].
+  @observable bool isLoading;
+  /// Is the suggestion list popup visible?
+  @observable bool suggestionsOpened;
+
+  StreamSubscription _oracleSub;
+
+  SparkSuggestBox.created() : super.created();
+
+  /// Shows the suggestion list popup with the given suggestions.
+  void _showSuggestions(List<Suggestion> update) {
+    suggestions.clear();
+    suggestions.addAll(update);
+    selectionIndex = 0;
+    suggestionsOpened = true;
+  }
+
+  /// Hides the suggestion list popup and clears the suggestion list.
+  void _hideSuggestions() {
+    suggestions.clear();
+    selectionIndex = -1;
+    suggestionsOpened = false;
+  }
+
+  inputKeyUp(KeyboardEvent e) {
+    if (e.keyCode == SparkWidget.DOWN_KEY) {
+      if (suggestionsOpened) {
+        // List of suggestions already visible. Simply advance the selection.
+        selectionIndex++;
+        _clampSelectionIndex();
+      } else {
+        // Look for suggestions
+        suggest();
+      }
+    } else if (e.keyCode == SparkWidget.UP_KEY) {
+      selectionIndex--;
+      _clampSelectionIndex();
+    } else if (e.keyCode == SparkWidget.ENTER_KEY) {
+      if (suggestionsOpened && selectionIndex > -1) {
+        _selectSuggestion(selectionIndex);
+      } else {
+        suggest();
+      }
+    } else if (e.keyCode == SparkWidget.ESCAPE_KEY) {
+      _hideSuggestions();
+    } else {
+      suggest();
+    }
+  }
+
+  void suggest() {
+    InputElement textBox = $['text-box'];
+    _cleanupSubscriptions();
+    isLoading = true;
+    _oracleSub = oracle.getSuggestions(textBox.value)
+        .listen((List<Suggestion> update) {
+          if (update != null && update.isNotEmpty) {
+            _showSuggestions(update);
+          } else {
+            _hideSuggestions();
+          }
+        }, onDone: _cleanupSubscriptions);
+  }
+
+  void _cleanupSubscriptions() {
+    if (_oracleSub != null) {
+      _oracleSub.cancel();
+      _oracleSub = null;
+      isLoading = false;
+    }
+  }
+
+  int _itemIndexForEvent(Event evt) {
+    Element itemDiv = evt.currentTarget;
+    return int.parse(itemDiv.attributes['item-index']);
+  }
+
+  void _selectSuggestion(int index) {
+    suggestions[index].onSelected();
+    _hideSuggestions();
+  }
+
+  void mouseOverItem(MouseEvent evt) {
+    selectionIndex = _itemIndexForEvent(evt);
+  }
+
+  void mouseClickedItem(MouseEvent evt) {
+    _selectSuggestion(_itemIndexForEvent(evt));
+  }
+
+  void _clampSelectionIndex() {
+    if (selectionIndex < -1) {
+      selectionIndex = -1;
+    } else if (selectionIndex > suggestions.length - 1) {
+      selectionIndex = suggestions.length - 1;
+    }
+  }
+}

--- a/widgets/lib/spark_suggest/spark_suggest_box.html
+++ b/widgets/lib/spark_suggest/spark_suggest_box.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+
+<!-- Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+     All rights reserved. Use of this source code is governed by a BSD-style
+     license that can be found in the LICENSE file. -->
+
+<!--
+/**
+ * spark-suggest-box displays suggestions based on text entered by a user and
+ * allows the user select one using either mouse or keyboard (using the arrow
+ * keys and the "enter" key).
+ *
+ * The suggestions themselves are supplied by a [SuggestOracle] passed via the
+ * [oracle] attribute. Placehoder text can be provided via the [placeholder]
+ * attribute.
+ *
+ * Example:
+ *   <spark-suggest-box oracle="{{colorOracle}}" placeholder="Pick a color...">
+ *   </spark-suggest-box>
+ */
+-->
+
+<link rel="import" href="../../../packages/spark_widgets/common/spark_widget.html"/>
+
+<polymer-element name="spark-suggest-box" extends="spark-widget"
+    attributes="oracle placeholder">
+  <template>
+    <!-- BUG: https://code.google.com/p/dart/issues/detail?id=14382 -->
+    <!-- link rel="stylesheet" href="xyz.css" -->
+    <style>
+      @import url("packages/spark_widgets/spark_suggest/spark_suggest_box.css");
+    </style>
+
+    <input
+        id="text-box"
+        type="search"
+        focused
+        placeholder="{{placeholder}}"
+        on-keyup="{{inputKeyUp}}" />
+
+    <spark-overlay
+        id="suggestion-list-overlay"
+        opened="{{suggestionsOpened}}"
+        class="spark-overlay-scale-slideup">
+      <div class="suggest-item-list">
+        <template if="{{isLoading}}">
+          <!--
+            TODO(yjbanov): Move this into spark-status and use spark-status
+                           instead of this custom indicator.
+           -->
+          <div id="loading-indicator">
+            <div id="r0">
+              <div id="r1"></div><div id="r2"></div>
+              <div id="r3"></div><div id="r4"></div>
+              <div id="r5"></div><div id="r6"></div>
+              <div id="r7"></div><div id="r8"></div>
+            </div>
+          </div>
+        </template>
+        <template repeat="{{s in suggestions | enumerate}}">
+          <!--
+            TODO: Consider reusing existing component, e.g. spark-selection
+          -->
+          <div
+              item-index="{{s.index}}"
+              class="suggest-item"
+              highlighted="{{s.index == selectionIndex}}"
+              on-mouseover="{{mouseOverItem}}"
+              on-click="{{mouseClickedItem}}">
+            {{s.value.displayLabel}}
+          </div>
+        </template>
+      </div>
+    </spark-overlay>
+  </template>
+
+  <script type="application/dart" src="spark_suggest_box.dart"></script>
+</polymer-element>


### PR DESCRIPTION
High level design:
- A common widget <spark-suggest-box> that takes user-supplied SuggestOracle as a source of suggestions
- A SearchOracle implementation for searching files
- The two come together as the new search box on the toolbar (spark_polymer_ui.*)
