### PR TITLE
add an error dialog

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -439,10 +439,23 @@ class Spark extends SparkModel implements FilesControllerDelegate {
     statusComponent.temporaryMessage = message;
   }
 
-  void showErrorMessage(String title, String message) {
-    // TODO: Implement.
+  SparkDialog _errorDialog;
 
-    print('${title}: ${message}');
+  /**
+   * Show a model error dialog.
+   */
+  void showErrorMessage(String title, String message) {
+    if (_errorDialog == null) {
+      _errorDialog = createDialog(getDialogElement('#errorDialog'));
+      _errorDialog.element.querySelector("[primary]").onClick.listen((_) {
+        querySelector("#modalBackdrop").style.display = "none";
+      });
+    }
+
+    _errorDialog.element.querySelector('#errorTitle').innerHtml = title;
+    _errorDialog.element.querySelector('#errorMessage').text = message;
+
+    _errorDialog.show();
   }
 
   void onSplitViewUpdate(int position) { }

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -100,6 +100,21 @@
       </div>
     </spark-modal>
 
+    <!-- Error dialog -->
+    <spark-modal id="errorDialog" class="spark-overlay-scale-slideup">
+      <div class="modal-body">
+        <div class="form-group">
+          <label id="errorTitle"></label>
+          <div id="errorMessage" class="help-block"></div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <spark-button id="errorClose" overlay-toggle primary focused data-dismiss="modal">
+          Close
+        </spark-button>
+      </div>
+    </spark-modal>
+
     <!-- Rename File dialog -->
     <spark-overlay id="renameDialog" class="spark-overlay-scale-slideup">
       <div class="modal-body">


### PR DESCRIPTION
Add a basic error dialog to replace our print() code. Fixes #693. This is something we can iterate on, to make it non-model.

![screen shot 2014-01-21 at 5 21 40 pm](https://f.cloud.github.com/assets/1269969/1970216/b3bc9ac0-8303-11e3-86ce-ab8b68ecd213.png)

@dinhviethoa 
