### PR TITLE
Call super.enteredView() in enterView override

### DIFF
--- a/widgets/lib/spark_splitter/spark_splitter.dart
+++ b/widgets/lib/spark_splitter/spark_splitter.dart
@@ -78,6 +78,8 @@ class SparkSplitter extends SparkWidget {
   /// Triggered when the control is first displayed.
   @override
   void enteredView() {
+    super.enteredView();
+
     // TODO(sergeygs): Perhaps switch to using onDrag* instead of onMouse* once
     // support for drag-and-drop in shadow DOM is fixed. It is less important
     // here, because the element is not actually supposed to be dropped onto


### PR DESCRIPTION
TBR: @terrylucas

It seemed to work without this, but this is a prescription coming from Polymer itself, so we'd better follow.
