### PR TITLE
spark-menu-item: remove hover style when clicked

### DIFF
--- a/widgets/lib/spark_menu/spark_menu.css
+++ b/widgets/lib/spark_menu/spark_menu.css
@@ -30,7 +30,3 @@
   border-bottom: 1px solid #EEE;
   cursor: default;
 }
-
-::content spark-menu-item:hover {
-  color: #fff;
-}

--- a/widgets/lib/spark_menu_item/spark_menu_item.css
+++ b/widgets/lib/spark_menu_item/spark_menu_item.css
@@ -12,8 +12,11 @@ spark-icon, .labelText, .labelText > * {
   display: inline-block;
 }
 
-:host:hover {
-  color: #fff;
+.highlight {
   opacity: 1 !important;
   background: #3a84c3;
+}
+
+.highlight .labelText {
+  color: #fff;
 }

--- a/widgets/lib/spark_menu_item/spark_menu_item.dart
+++ b/widgets/lib/spark_menu_item/spark_menu_item.dart
@@ -21,5 +21,13 @@ class SparkMenuItem extends SparkWidget {
   /// Specifies the label for the menu item.
   @published String label = "";
 
+  void hover_style() {
+    classes.add('highlight');
+  }
+
+  void clean_hover_style() {
+    classes.remove('highlight');
+  }
+
   SparkMenuItem.created(): super.created();
 }

--- a/widgets/lib/spark_menu_item/spark_menu_item.html
+++ b/widgets/lib/spark_menu_item/spark_menu_item.html
@@ -16,7 +16,10 @@
 <link rel="import" href="../../../packages/spark_widgets/spark_icon/spark_icon.html">
 
 <polymer-element name="spark-menu-item" extends="spark-widget"
-    attributes="src label iconsize">
+    attributes="src label iconsize"
+    on-mouseover="{{hover_style}}"
+    on-mouseout="{{clean_hover_style}}"
+    on-click="{{clean_hover_style}}">
   <template>
     <!-- BUG: https://code.google.com/p/dart/issues/detail?id=14382 -->
     <!-- link rel="stylesheet" href="xyz.css" -->


### PR DESCRIPTION
Fixes : https://github.com/dart-lang/spark/issues/676

TEST=Manually Click menu item.
