### PR TITLE
fix an issue w/ exceptions when traversing the list of editors

### DIFF
--- a/ide/app/lib/editors.dart
+++ b/ide/app/lib/editors.dart
@@ -156,7 +156,7 @@ class EditorManager implements EditorProvider {
         }
       }
 
-      _editorMap[file] = null;
+      _editorMap.remove(file);
 
       persistState();
     }


### PR DESCRIPTION
TBR @dinhviethoa, fix an issue where a `null` editor would be in the editor map, and traversing the list of editors would cause an NPE.

This would cause dart files to not analyze after a series of opening and closing files.
