### PR TITLE
Removed obsolete and no-longer-allowed permissions

### DIFF
--- a/ide/app/manifest.json
+++ b/ide/app/manifest.json
@@ -39,7 +39,6 @@
         "tcp-listen"
       ]
     },
-    "management",
     "syncFileSystem",
     "storage",
     "webview",


### PR DESCRIPTION
@gaurave PTAL. I'm most probably mistaken about 'management': I've just looked up file history and saw that you added it just 8 days ago - are we supposed to be whitelisted for it?

The 'app.window' one is for sure correct (I know the history behind it).
