### PR TITLE
fix a failing editor test

### DIFF
--- a/ide/app/lib/editors.dart
+++ b/ide/app/lib/editors.dart
@@ -255,7 +255,7 @@ class EditorManager implements EditorProvider {
           if (editorType(state.file.name) == EDITOR_TYPE_IMAGE) {
             _selectedController.add(currentFile);
             persistState();
-          } else {
+          } else if (_editorMap[currentFile] != null) {
             // TODO: this explicit casting to AceEditor will go away in a future refactoring
             ace.TextEditor textEditor = _editorMap[currentFile];
             textEditor.setSession(state.session);

--- a/ide/app/lib/ui/widgets/treeview_cell.dart
+++ b/ide/app/lib/ui/widgets/treeview_cell.dart
@@ -5,7 +5,6 @@
 library spark.ui.widgets.treeview_cell;
 
 import 'dart:html';
-import 'dart:async';
 import 'dart:convert' show JSON;
 
 import 'listview_cell.dart';

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -10,7 +10,6 @@ import 'dart:html' hide File;
 
 import 'package:bootjack/bootjack.dart' as bootjack;
 import 'package:chrome/chrome_app.dart' as chrome;
-import 'package:dquery/dquery.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 

--- a/ide/app/test/git/file_operations_test.dart
+++ b/ide/app/test/git/file_operations_test.dart
@@ -4,7 +4,6 @@
 
 library git_file_operations_test;
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:html';
 import 'dart:typed_data';

--- a/ide/app/test/search_test.dart
+++ b/ide/app/test/search_test.dart
@@ -4,8 +4,6 @@
 
 library spark.search_test;
 
-import 'dart:async';
-
 import 'package:spark_widgets/spark_suggest/spark_suggest_box.dart';
 import 'package:unittest/unittest.dart';
 


### PR DESCRIPTION
Fixes #899 - one of our tests was driving the editor manager in a way it wasn't expecting. Also, cleanup up some unused imports which a new version of the analyzer found.

@ussuri 
