### PR TITLE
Fix spark-suggest-box exception when starting to enter text

### DIFF
--- a/widgets/lib/spark_suggest/spark_suggest_box.dart
+++ b/widgets/lib/spark_suggest/spark_suggest_box.dart
@@ -17,6 +17,7 @@ import '../common/spark_widget.dart';
  * and an [onSelected] callback. [onSelected] is called when the user chooses
  * `this` suggestion.
  */
+@reflectable
 class Suggestion {
   final String label;
   final String details;


### PR DESCRIPTION
The exception was: "Uncaught Error: Unsupported operation: Can't use 'label' in reflection because it is not included in a @MirrorsUsed annotation." See discussion of the ways to fix here: https://groups.google.com/a/dartlang.org/forum/#!topic/web/ZcChqcRedgg

TBR: @yjbanov @devoncarew
