### PR TITLE
spark-suggest-box: use bootstrap styling on search box

### DIFF
--- a/widgets/lib/spark_suggest/spark_suggest_box.css
+++ b/widgets/lib/spark_suggest/spark_suggest_box.css
@@ -5,18 +5,7 @@
 @import url("../common/spark_widget.css");
 
 #text-box {
-  outline: none;
-  border-radius: 3px;
-  border: 1px solid #cccccc;
-  padding: 2px 3px 2px 0px;
-  width: 100%;
-  font-size: 14px;
-  font-family: Helvetica, sans-serif;
   height: 31px;
-}
-
-#text-box:focus {
-  border-color: #aaaaaa;
 }
 
 #suggestion-list-overlay {

--- a/widgets/lib/spark_suggest/spark_suggest_box.html
+++ b/widgets/lib/spark_suggest/spark_suggest_box.html
@@ -35,6 +35,7 @@
     <input
         id="text-box"
         type="search"
+        class="form-control"
         focused
         placeholder="{{placeholder}}"
         on-keyup="{{inputKeyUp}}"


### PR DESCRIPTION
Use bootstrap styling.
Fixes https://github.com/dart-lang/spark/issues/947

Review : @dinhviethoa
cc : @ussuri

![image](https://f.cloud.github.com/assets/756988/2058667/e69a6850-8b7d-11e3-8e63-7641f626a99c.png)
