### PR TITLE
Move context menu if cropped

### DIFF
--- a/ide/app/lib/ui/files_controller.dart
+++ b/ide/app/lib/ui/files_controller.dart
@@ -688,8 +688,9 @@ class FilesController implements TreeViewDelegate {
     // Position the context menu at the expected location.
     contextMenu.style.left = '${position.x}px';
     contextMenu.style.top = '${position.y}px';
+    // Hide until we get correct top position.
+    contextMenu.style.visibility = "hidden";
 
-    // Show the menu.
     bootjack.Dropdown dropdown = bootjack.Dropdown.wire(contextMenu);
     dropdown.toggle();
 
@@ -697,6 +698,9 @@ class FilesController implements TreeViewDelegate {
     // Move context menu if it will show cropped.
     if (contextMenu.offsetHeight + position.y > backdrop.offsetHeight)
       contextMenu.style.top = '${position.y - contextMenu.offsetHeight}px';
+
+    // Show the menu.
+    contextMenu.style.visibility = "visible";
 
     void _closeContextMenu(html.Event event) {
       // We workaround an issue with bootstrap/boojack: There's no other way


### PR DESCRIPTION
Fixes https://github.com/dart-lang/spark/issues/835
Honestly, I'm uncomfortable because the context moves after showing(but unable to catch by human eyes)

review @dinhviethoa
