### PR TITLE
fix issues with git library names and parameter types

### DIFF
--- a/ide/app/lib/git/commands/fetch.dart
+++ b/ide/app/lib/git/commands/fetch.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library git.commands.pull;
+library git.commands.fetch;
 
 import 'dart:async';
 import 'dart:typed_data';

--- a/ide/app/lib/git/object.dart
+++ b/ide/app/lib/git/object.dart
@@ -23,7 +23,7 @@ abstract class GitObject {
    * Constructs a GitObject of the given type. [content] can be of type [String]
    * or [Uint8List].
    */
-  static GitObject make(String sha, String type, content,
+  static GitObject make(String sha, String type, var content,
                         [LooseObject rawObj]) {
     switch (type) {
       case ObjectTypes.BLOB_STR:
@@ -131,7 +131,7 @@ class TreeObject extends GitObject {
  */
 class BlobObject extends GitObject {
 
-  BlobObject(String sha, Uint8List data) : super(sha, data) {
+  BlobObject(String sha, var data) : super(sha, data) {
     this.type = ObjectTypes.BLOB_STR;
   }
 }

--- a/ide/app/test/git/all.dart
+++ b/ide/app/test/git/all.dart
@@ -9,6 +9,7 @@ import 'commands/checkout_test.dart' as git_commands_checkout_test;
 import 'commands/clone_test.dart' as git_commands_clone_test;
 import 'commands/commit_test.dart' as git_commands_commit_test;
 import 'commands/conditions_test.dart' as git_commands_conditions_test;
+import 'commands/fetch_test.dart' as git_commands_fetch_test;
 import 'commands/merge_test.dart' as git_commands_merge_test;
 import 'commands/pull_test.dart' as git_commands_pull_test;
 import 'commands/push_test.dart' as git_commands_push_test;
@@ -29,6 +30,7 @@ void defineTests() {
   git_commands_commit_test.defineTests();
   git_commands_clone_test.defineTests();
   git_commands_conditions_test.defineTests();
+  git_commands_fetch_test.defineTests();
   git_commands_merge_test.defineTests();
   git_commands_pull_test.defineTests();
   git_commands_push_test.defineTests();

--- a/ide/app/test/git/commands/fetch_test.dart
+++ b/ide/app/test/git/commands/fetch_test.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library git_merge_test;
+library git_fetch_test;
 
 import 'package:unittest/unittest.dart';
 


### PR DESCRIPTION
- fix some library names (and remove a compiler warning)
- fix an issue with a param being specified as `Uint8List` when either `Uint8List` or `String` are allowed

TBR, @gaurave
