### PR TITLE
Utils fix for commit / clone.

### DIFF
--- a/ide/app/lib/git/utils.dart
+++ b/ide/app/lib/git/utils.dart
@@ -41,7 +41,7 @@ String shaBytesToString(List shaBytes) {
 
 Future<String> getShaForEntry(chrome.ChromeFileEntry entry, String type) {
   return entry.readBytes().then((chrome.ArrayBuffer content) => _getShaForData(
-      content, type));
+      new Uint8List.fromList(content.getBytes()), type));
 }
 
 Future<String> getShaForString(String data, String type) {
@@ -64,7 +64,11 @@ Future<String> _getShaForData(dynamic content, String type) {
     throw "Unexpected content type.";
   }
 
-  Uint8List data = new Uint8List.fromList(content.getBytes());
+  Uint8List data;
+  if (content is Uint8List)
+    data = content;
+  else
+    data = new Uint8List.fromList(content.getBytes());
 
   String header = '${type} ${size}' ;
   blobParts.add(header);


### PR DESCRIPTION
Small error found in utils.dart.
Clone and commit both fail without these changes (i.e. getShaForString cannot handle ArrayBuffer... all other instances of readBytes() convert the result to Uint8List for use elsewhere).
Similarly, running .getBytes() on a Uint8List fails.
