### PR TITLE
fix an exception when starting spark

### DIFF
--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -156,7 +156,7 @@ class SparkPolymer extends Spark {
       if (position != null) {
         int value = int.parse(position, onError: (_) => 0);
         if (value != 0) {
-          (getUIElement('#splitView') as SparkSplitView).targetSize = value;
+          (getUIElement('#splitView') as dynamic).targetSize = value;
         }
       }
     });


### PR DESCRIPTION
@ussuri, fix an exception when starting up Spark, when compiled to JS

I think this is related to mixing `package:` and path imports with the polymer UI code. I.e., their are two different runtime types for the `SparkSplitView` class. Not 100% sure about this though. When compiling via dart2js, supposedly you need to add an explicit flag in order for it to insert 'checked mode' checks.

```
CastError: Casting value of type SparkSplitView0 to incompatible type SparkSplitView spark_polymer.html_bootstrap.dart.js:137011
Error
    at dart.wrapException (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:2781:15)
    at dart.propertyTypeCastError (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:3105:13)
    at dart.interceptedTypeCast (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:3115:7)
    at SparkPolymer_initSplitView_closure.call$1 (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:150906:64)
    at _rootRunUnary (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:16950:16)
    at _ZoneDelegate.runUnary$3 (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:19395:32)
    at _CustomizedZone.runUnary$2 (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:19593:40)
    at _Future__propagateToListeners_handleValueCallback.call$0 (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:17745:57)
    at dart._Future.static._Future__propagateToListeners (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:17656:120)
    at _Future._complete$1 (chrome-extension://kcjgcakhgelcejampmijgkjkadfcncjl/spark_polymer.html_bootstrap.dart.js:17545:9) 
```
