### PR TITLE
Close dialog when ESC is pressed

### DIFF
--- a/widgets/lib/spark_modal/spark_modal.dart
+++ b/widgets/lib/spark_modal/spark_modal.dart
@@ -7,6 +7,7 @@ library spark_widgets.modal;
 import 'dart:html';
 import 'package:polymer/polymer.dart';
 
+import '../common/spark_widget.dart';
 import '../spark_overlay/spark_overlay.dart';
 
 // Ported from Polymer Javascript to Dart code.
@@ -15,8 +16,7 @@ import '../spark_overlay/spark_overlay.dart';
 class SparkModal extends SparkOverlay {
   @override
   void keydownHandler(KeyboardEvent e) {
-    final int ESCAPE_KEY = 27;
-    if (e.keyCode == ESCAPE_KEY) {
+    if (e.keyCode == SparkWidget.ESCAPE_KEY) {
       this.opened = false;
       e.stopImmediatePropagation();
       e.preventDefault();


### PR DESCRIPTION
`spark-modal` has `autoCloseDisabled` property which block closing dialog when ESC is pressed.
This makes override `keydownHandler` not to block it.

Fixes https://github.com/dart-lang/spark/issues/967
review @ussuri
TEST=Open `Git Clone` Dialog and press ESC key. Check the dialog is being closed.
