### PR TITLE
Fix the exception caused by <spark-button> in #editor-dialog in Dartium 33

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -24,8 +24,6 @@ import 'workspace.dart' as workspace;
 
 export 'package:ace/ace.dart' show EditSession;
 
-import '../packages/spark_widgets/spark_button/spark_button.dart';
-
 class TextEditor extends Editor {
   final AceManager aceManager;
   final workspace.File file;
@@ -332,7 +330,7 @@ class AceManager {
     dialog.append(element);
 
     // Set actions of the dialog.
-    SparkButton button = dialog.querySelector('.view-as-text-button');
+    html.ButtonElement button = dialog.querySelector('.view-as-text-button');
     button.onClick.listen((_) {
       dialog.classes.add("transition-hidden");
       focus();

--- a/ide/app/spark_polymer.html
+++ b/ide/app/spark_polymer.html
@@ -43,7 +43,7 @@
           <div>Spark can't show the content of files of this type.</div>
         </div>
         <div>
-          <spark-button class="view-as-text-button">Edit as text</spark-button>
+          <button class="view-as-text-button">Edit as text</button>
         </div>
       </div>
       <div class="always-view-as-text-button">


### PR DESCRIPTION
@dinhviethoa This is rough patch for #1078. The button that replaces the `<spark-button>` is not styled. Maybe this would be an acceptable temporary patch until we reimplement the dialog in editor_area.dart and spark_polymer_ui.html.
