### PR TITLE
Add support for pushing a Chrome app to the Chrome ADT on mobile.

### DIFF
--- a/ide/app/lib/harness_push.dart
+++ b/ide/app/lib/harness_push.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark.harness_push;
+
+import 'dart:async';
+import 'dart:html';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart' as archive;
+import 'package:chrome/chrome_app.dart' as chrome;
+
+import '../spark_model.dart';
+import 'jobs.dart';
+import 'workspace.dart' as ws;
+
+class HarnessPush {
+  /**
+   * Packages (a subdirectory of) the current project, and sends it via HTTP to
+   * a remote host.
+   *
+   * It expects the target host, and a [ProgressMonitor] for 10 units of work.
+   * All files under the project will be added to a (slightly broken, see
+   * below) CRX file, and sent via HTTP POST to the target host, using the /push
+   * protocol described [here](https://github.com/MobileChromeApps/harness-push).
+   *
+   *     HarnessPush.push('192.168.1.121', monitor);
+   *
+   * Returns a Future for the push operation.
+   *
+   * Important Note: The CRX file that gets created and pushed is not correctly
+   * signed and does not include the application's key. Since the target of a
+   * push is intended to be a tool like the
+   * [Chrome ADT](https://github.com/MobileChromeApps/harness) on Android,
+   * and that tool doesn't care about the CRX metadata, this is not a problem.
+   */
+  static Future push(String target, ProgressMonitor monitor) {
+    ws.Project project = SparkModel.instance.workspace.getProjects().first;
+    if (project == null) {
+      return new Future.error(new ArgumentError(
+            'Could not find project to push'));
+    }
+
+    archive.Archive arch = new archive.Archive();
+    return _recursiveArchive(arch, project, '' /* path prefix */)
+        .then((_) {
+      monitor.worked(3);
+      List<int> httpRequest = [];
+      // Build the HTTP request headers.
+      String boundary = "--------------------------------a921a8f557cf";
+      String header = "POST /push?name=${project.name}&type=crx HTTP/1.1\r\n"
+          + "User-Agent: Spark IDE\r\n"
+          + "Host: ${target}:2424\r\n"
+          + "Content-Type: multipart/form-data; boundary=$boundary\r\n";
+      List<int> body = [];
+      String bodyTop = "$boundary\r\n"
+          + "Content-Disposition: form-data; name=\"file\"; "
+          + "filename=\"SparkPush.crx\"\r\n"
+          + "Content-Type: application/octet-stream\r\n\r\n";
+      body.addAll(bodyTop.codeUnits);
+
+      // Add the CRX headers before the zip content.
+      // This is the string "Cr24" then three little-endian 32-bit numbers:
+      // - The version (2).
+      // - The public key length (0).
+      // - The signature length (0).
+      // Since the App Harness/Chrome ADT on the other end doesn't check
+      // the signature or key, we don't bother sending them.
+      body.addAll(
+          [67, 114, 50, 52, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+      // Now follows the actual zip data.
+      body.addAll(new archive.ZipEncoder().encode(arch));
+      monitor.worked(4);
+
+      // Add the trailing boundary.
+      body.addAll([13, 10]); // \r\n
+      body.addAll(boundary.codeUnits);
+      // Two trailing hyphens to indicate the final boundary.
+      body.addAll([45, 45, 13, 10]); // --\r\n
+
+      httpRequest.addAll(header.codeUnits);
+      httpRequest.addAll("Content-length: ${body.length}\r\n\r\n".codeUnits);
+      httpRequest.addAll(body);
+
+      monitor.worked(1);
+      chrome.ArrayBuffer payload = new chrome.ArrayBuffer.fromBytes(
+          httpRequest);
+      // Now create a chrome.socket and send it.
+      int socketId;
+      return chrome.socket.create(chrome.SocketType.TCP).then((createInfo) {
+        if (chrome.runtime.lastError != null) {
+          throw 'Error creating socket';
+        }
+        socketId = createInfo.socketId;
+        return chrome.socket.connect(socketId, target, 2424);
+      }).then((_) {
+        if (chrome.runtime.lastError != null) {
+          throw 'Connection error: ${chrome.runtime.lastError.toString()}';
+        }
+        return chrome.socket.write(socketId, payload);
+      }).then((chrome.SocketWriteInfo writeInfo) {
+        if (chrome.runtime.lastError != null) {
+          throw 'Failed to write to socket.';
+        }
+        print('Successfully pushed! (${writeInfo.bytesWritten} bytes)');
+        monitor.worked(2);
+      }).catchError((e) {
+        SparkModel.instance.showErrorMessage('Push failure', e);
+      }).whenComplete(() {
+        if (socketId != null) {
+          chrome.socket.disconnect(socketId);
+          chrome.socket.destroy(socketId);
+        }
+        SparkModel.instance.showSuccessMessage('Push successful');
+      });
+    });
+  }
+
+  static _recursiveArchive(archive.Archive arch, ws.Resource parent,
+      String prefix) {
+    List<ws.Resource> children = (parent as ws.Container).getChildren();
+    List<Future> futures = [];
+
+    for (ws.Resource child in children) {
+      if (child is ws.File) {
+        futures.add((child as ws.File).getBytes().then((buf) {
+          List<int> data = buf.getBytes();
+          arch.addFile(new archive.File(prefix + child.name, data.length,
+              data));
+        }));
+      } else if (child is ws.Folder) {
+        futures.add(_recursiveArchive(arch, child, prefix + child.name + '/'));
+      }
+    }
+
+    return Future.wait(futures);
+  }
+}
+
+

--- a/ide/app/manifest.json
+++ b/ide/app/manifest.json
@@ -23,6 +23,7 @@
   "permissions": [
     "https://www.google-analytics.com/",
     "https://github.com/*",
+    "http://*/push",
     "clipboardRead",
     "clipboardWrite",
     "developerPrivate",

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -25,6 +25,7 @@ import 'lib/dart/dart_builder.dart';
 import 'lib/editors.dart';
 import 'lib/editor_area.dart';
 import 'lib/event_bus.dart';
+import 'lib/harness_push.dart';
 import 'lib/jobs.dart';
 import 'lib/launch.dart';
 import 'lib/preferences.dart' as preferences;
@@ -385,6 +386,7 @@ class Spark extends SparkModel implements FilesControllerDelegate,
     actionManager.registerAction(new FileRenameAction(this, getDialogElement('#renameDialog')));
     actionManager.registerAction(new ResourceRefreshAction(this));
     actionManager.registerAction(new ApplicationRunAction(this));
+    actionManager.registerAction(new ApplicationPushAction(this, getDialogElement('#pushDialog')));
     actionManager.registerAction(new GitCloneAction(this, getDialogElement("#gitCloneDialog")));
     actionManager.registerAction(new GitBranchAction(this, getDialogElement("#gitBranchDialog")));
     actionManager.registerAction(new GitCheckoutAction(this, getDialogElement("#gitCheckoutDialog")));
@@ -1387,6 +1389,37 @@ class FolderOpenAction extends SparkAction {
 
   void _invoke([Object context]) {
     spark.openFolder();
+  }
+}
+
+class ApplicationPushAction extends SparkActionWithDialog {
+  InputElement _pushUrlElement;
+
+  ApplicationPushAction(Spark spark, Element dialog)
+      : super(spark, "application-push", "Push to Mobile", dialog) {
+    _pushUrlElement = _triggerOnReturn("#pushUrl");
+  }
+
+  void _invoke([Object context]) {
+    _show();
+  }
+
+  void _commit() {
+    String url = _pushUrlElement.value;
+    // TODO(braden): Input validation.
+    spark.jobManager.schedule(new _HarnessPushJob(url));
+  }
+}
+
+
+class _HarnessPushJob extends Job {
+  String _url;
+
+  _HarnessPushJob(this._url) : super('Pushing to mobile…');
+
+  Future run(ProgressMonitor monitor) {
+    monitor.start(name, 10);
+    return HarnessPush.push(_url, monitor);
   }
 }
 

--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -189,6 +189,7 @@ class SparkPolymer extends Spark {
     _bindButtonToAction('gitClone', 'git-clone');
     _bindButtonToAction('newProject', 'project-new');
     _bindButtonToAction('runButton', 'application-run');
+    _bindButtonToAction('pushButton', 'application-push');
   }
 
   @override

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -33,6 +33,7 @@
       <spark-button id="runButton" small primary>
         <span class="glyphicon glyphicon-play"></span> Run
       </spark-button>
+      <spark-button id="pushButton" small>Push to Mobile</spark-button>
       <spark-button id="newProject" small>New Project...</spark-button>
       <spark-button id="gitClone" small>Git Clone...</spark-button>
 
@@ -194,6 +195,28 @@
         </spark-button>
         <spark-button overlay-toggle primary data-dismiss="modal">
           Create
+        </spark-button>
+      </div>
+    </spark-modal>
+
+    <!-- Harness Push dialog -->
+    <spark-modal id="pushDialog" class="dialog spark-overlay-scale-slideup">
+      <div class="modal-header">
+        <a href="#" class="close" overlay-toggle>&times;</a>
+        <h4 class="modal-title">Push to Mobile</h4>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label for="pushUrl">Target Host</label>
+          <input id="pushUrl" type="text" class="form-control" placeholder="e.g. 192.168.1.101" />
+        </div>
+      </div>
+      <div class="modal-footer">
+        <spark-button overlay-toggle data-dismiss="modal">
+          Cancel
+        </spark-button>
+        <spark-button overlay-toggle primary data-dismiss="modal">
+          Push
         </spark-button>
       </div>
     </spark-modal>


### PR DESCRIPTION
This adds a new button next to "Run" that packages a CRX file and sends
it to a mobile device. The protocol for pushes is defined at:
https://github.com/MobileChromeApps/harness-push

Caveat: This code uses chrome.socket to make the HTTP request directly,
due to problems encountered while trying to use HttpRequest. The
HttpRequest code is much more compact, if the issues with it are
resolved.
