### PR TITLE
Add spark-split-view example to top index.html + cleanup the example

### DIFF
--- a/widgets/example/examples.dart
+++ b/widgets/example/examples.dart
@@ -12,13 +12,11 @@ class Examples extends PolymerElement {
                  'spark_menu_button',
                  'spark_menu_item',
                  'spark_overlay',
-                 'spark_selection',
                  'spark_selector',
+                 'spark_split_view',
                  'spark_splitter',
                  'spark_toggle_button',
                  'spark_toolbar'];
-
-  factory Examples() => new Element.tag('Examples');
 
   Examples.created() : super.created();
 }

--- a/widgets/example/examples.html
+++ b/widgets/example/examples.html
@@ -7,26 +7,25 @@
         font-family: 'sans-serif';
       }
 
-      a, a:visited {
-        color: #00f;
+      a {
+        color: blue;
       }
 
-      a.disabled_link {
-        pointer-events: none;
-        cursor: default;
-        text-decoration: none;
-        color: #888;
+      a:visited {
+        color: purple;
       }
     </style>
+
     <div>
       <ul>
-        <template repeat="{{link in links | enumerate}}">
-            <li>
-              <a href='{{link.value}}/index.html'>{{link.value}}</a>
-            </li>
+        <template repeat="{{link in links}}">
+          <li>
+            <a href='{{link}}/index.html'>{{link}}</a>
+          </li>
         </template>
       </ul>
     </div>
   </template>
+
   <script type="application/dart" src="examples.dart"></script>
 </polymer-element>

--- a/widgets/example/index.html
+++ b/widgets/example/index.html
@@ -3,13 +3,13 @@
 <html>
   <head>
     <title>Spark Widget Examples</title>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <link rel="import" href="examples.html">
   </head>
+
   <body>
     <div>Spark Widget Examples:</div>
     <widget-examples></widget-examples>
   </body>
+
   <script type="application/dart">export "package:polymer/init.dart";</script>
 </html>

--- a/widgets/example/spark_split_view/example_ui.html
+++ b/widgets/example/spark_split_view/example_ui.html
@@ -4,31 +4,29 @@
 
 <polymer-element name="example-ui">
   <template>
-    <spark-split-view direction="left" style="width:400px; height:100px">
-      <div style="background-color:lightblue; width:200px">left (resize target)</div>
-      <div style="background-color:lightgreen">right</div>
+    <spark-split-view direction="left" style="width:400px; height:200px">
+      <div style="background-color:lightblue; width:200px">left (resize)</div>
+      <div style="background-color:lightgreen">right (flex)</div>
     </spark-split-view>
 
-    <br>
-
-    <spark-split-view direction="right" style="width:400px; height:100px">
-      <div style="background-color:lightblue">left</div>
-      <div style="background-color:lightgreen; width:200px">right (resize target)</div>
+    <spark-split-view direction="right" style="width:400px; height:200px">
+      <div style="background-color:lightblue">left (flex)</div>
+      <div style="background-color:lightgreen; width:200px">right (resize)</div>
     </spark-split-view>
 
-    <br>
+    <br><br>
 
-    <spark-split-view direction="up" style="width:400px; height:200px">
-      <div style="background-color:orange; height:100px">top (resize target)</div>
-      <div style="background-color:yellow">bottom</div>
-    </spark-split-view>
+    <div style="display:flex; flex-flow:row">
+      <spark-split-view direction="up" style="width:200px; height:400px">
+        <div style="background-color:orange; height:200px">top (resize)</div>
+        <div style="background-color:yellow">bottom (flex)</div>
+      </spark-split-view>
 
-    <br>
-
-    <spark-split-view direction="down" style="width:400px; height:200px">
-      <div style="background-color:orange">top</div>
-      <div style="background-color:yellow; height:100px">bottom (resize target)</div>
-    </spark-split-view>
+      <spark-split-view direction="down" style="width:200px; height:400px">
+        <div style="background-color:orange">top (flex)</div>
+        <div style="background-color:yellow; height:200px">bottom (resize)</div>
+      </spark-split-view>
+    </div>
   </template>
 
   <script type="application/dart" src="example_ui.dart"></script>

--- a/widgets/example/spark_splitter/example_ui.html
+++ b/widgets/example/spark_splitter/example_ui.html
@@ -4,30 +4,30 @@
 <polymer-element name="example-ui">
   <template>
     <div style="display:flex; width:400px; height:200px">
-     <div style="width:200px; background-color:blue">left (resize target)</div>
-     <spark-splitter direction="left"></spark-splitter>
-     <div style="background-color:green; flex:1">right</div>
+      <div style="width:200px; background-color:lightblue">left (resize target)</div>
+      <spark-splitter direction="left"></spark-splitter>
+      <div style="background-color:lightgreen; flex:1">right</div>
     </div>
 
     <div style="display:flex; width:400px; height:200px">
-     <div style="background-color:blue; flex:1">left</div>
-     <spark-splitter direction="right"></spark-splitter>
-     <div style="width:200px; background-color:green">right (resize target)</div>
+      <div style="background-color:lightblue; flex:1">left</div>
+      <spark-splitter direction="right"></spark-splitter>
+      <div style="width:200px; background-color:lightgreen">right (resize target)</div>
     </div>
 
     <br><br>
 
     <div style="display:flex; flex-flow:row">
       <div style="display:flex; flex-flow:column; width:200px; height:400px">
-       <div style="height:200px; background-color:red">top (resize target)</div>
-       <spark-splitter direction="up"></spark-splitter>
-       <div style="background-color:yellow; flex:1">bottom</div>
+        <div style="height:200px; background-color:orange">top (resize target)</div>
+        <spark-splitter direction="up"></spark-splitter>
+        <div style="background-color:yellow; flex:1">bottom</div>
       </div>
 
       <div style="display:flex; flex-flow:column; width:200px; height:400px">
-       <div style="background-color:red; flex:1">top</div>
-       <spark-splitter direction="down"></spark-splitter>
-       <div style="height:200px; background-color:yellow">bottom (resize target)</div>
+        <div style="background-color:orange; flex:1">top</div>
+        <spark-splitter direction="down"></spark-splitter>
+        <div style="height:200px; background-color:yellow">bottom (resize target)</div>
       </div>
     </div>
   </template>


### PR DESCRIPTION
Also realized that vertical directions ("up" and "down") don't work as expected. The problem must be in the way spark-split-view determins and assigns flexbox styles to the top element and distributed contents: the underlying spark-splitter works fine (see its own example). Will file a bug and address later.

TBR
