### PR TITLE
TEMP Fixing vertical spark-split-view - DO NOT MERGE

### DIFF
--- a/widgets/lib/spark_split_view/spark_split_view.css
+++ b/widgets/lib/spark_split_view/spark_split_view.css
@@ -4,40 +4,38 @@
 
 @import url("../common/spark_widget.css");
 
-:host {
+#enclosure {
   display: flex;
+  height: 100%;
+  width: 100%;
 }
 
-:host[direction="left"], :host[direction="right"] {
+#enclosure[direction="left"], #enclosure[direction="right"] {
   flex-flow: row;
 }
 
-:host[direction="up"], :host[direction="down"] {
+#enclosure[direction="up"], #enclosure[direction="down"] {
   flex-flow: column;
-}
-
-::content > * {
-  position: relative;
 }
 
 /* If the resizing target is to the left or up, make the other one flex so
    it auto-adjusts.
 */
-#marker[direction="left"] ~ content[select=":nth-child(2)"]::content > * {
+#enclosure[direction="left"] > content[select=":nth-child(2)"]::content > * {
   flex: 1;
 }
 
-#marker[direction="up"] ~ content[select=":nth-child(2)"]::content > * {
+#enclosure[direction="up"] > content[select=":nth-child(2)"]::content > * {
   flex: 1;
 }
 
 /* If the resizing target is to the right or down, make the other one flex so
    it auto-adjusts.
 */
-#marker[direction="right"] ~ content[select=":nth-child(1)"]::content > * {
+#enclosure[direction="right"] > content[select=":nth-child(1)"]::content > * {
   flex: 1;
 }
 
-#marker[direction="down"] ~ content[select=":nth-child(1)"]::content > * {
+#enclosure[direction="down"] > content[select=":nth-child(1)"]::content > * {
   flex: 1;
 }

--- a/widgets/lib/spark_split_view/spark_split_view.html
+++ b/widgets/lib/spark_split_view/spark_split_view.html
@@ -43,19 +43,19 @@
     <!-- HACK: A temporary way to anchor `direction` to something in the
          shadowRoot to use for conditional styling of <content>. Discussion:
          https://groups.google.com/forum/#!topic/polymer-dev/NCYrR4OUvDI -->
-    <div id="marker" direction="{{direction}}"></div>
-
-    <!-- NOTE: The Dart side verifies that there is exactly 2 children -->
-    <content select=":nth-child(1)"></content>
-    <spark-splitter
-        id="splitter"
-        direction="{{direction}}"
-        size="{{splitterSize}}"
-        handle="{{splitterHandle}}"
-        locked="{{locked}}"
-        onUpdate="{{onUpdate}}">
-    </spark-splitter>
-    <content select=":nth-child(2)"></content>
+    <div id="enclosure" direction="{{direction}}">
+      <!-- NOTE: The Dart side verifies that there is exactly 2 children -->
+      <content select=":nth-child(1)"></content>
+      <spark-splitter
+          id="splitter"
+          direction="{{direction}}"
+          size="{{splitterSize}}"
+          handle="{{splitterHandle}}"
+          locked="{{locked}}"
+          onUpdate="{{onUpdate}}">
+      </spark-splitter>
+      <content select=":nth-child(2)"></content>
+    </div>
   </template>
 
   <script type="application/dart" src="spark_split_view.dart"></script>


### PR DESCRIPTION
This is a half-finished attempt to fix #1086. 

This fixes the vertical split-view in the example (widgets/examples/spark_split_view), but semi-breaks the horizontal one (it assumes the minimal possible height and 100% width, unlike before) and most importantly it breaks split-view in Spark (file tree panel disappears). Investigate further.

@sunglim It would be great if you could take a look and see if you can complete this fix (or come up with a different one). It has a lot to do with CSS, though, so no pressure :)
