### PR TITLE
remove the close action

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -401,7 +401,8 @@ class Spark extends SparkModel implements FilesControllerDelegate,
     actionManager.registerAction(new RunTestsAction(this));
     actionManager.registerAction(new SettingsAction(this, getDialogElement('#settingsDialog')));
     actionManager.registerAction(new AboutSparkAction(this, getDialogElement('#aboutDialog')));
-    actionManager.registerAction(new ResourceCloseAction(this));
+    // The top-level 'Close' action is removed for now: #1037.
+    //actionManager.registerAction(new ResourceCloseAction(this));
     actionManager.registerAction(new FileDeleteAction(this));
     actionManager.registerAction(new TabCloseAction(this));
     actionManager.registerAction(new TabPreviousAction(this));


### PR DESCRIPTION
@dinhviethoa, this removes the context menu's 'Close' item. It's fairly broken:
- sync-fs resources that you close, show up again the next time you start spark (#1037)
- closing a project doesn't close the associated open editors
- if you do close a sync-fs project, there's no way for the user to later re-open it

I'd like to remove this functionality until it's working better (and push re-enabling it off to a later milestone).
