### PR TITLE
introduce a temporary uuid class

### DIFF
--- a/ide/app/lib/ui/widgets/treeview.dart
+++ b/ide/app/lib/ui/widgets/treeview.dart
@@ -11,8 +11,6 @@ library spark.ui.widgets.treeview;
 import 'dart:collection';
 import 'dart:html';
 
-import 'package:uuid/uuid.dart';
-
 import 'treeview_cell.dart';
 import 'treeview_row.dart';
 import 'listview.dart';
@@ -20,6 +18,7 @@ import 'listview_cell.dart';
 import 'listview_delegate.dart';
 import 'treeview_delegate.dart';
 import '../utils/html_utils.dart';
+import '../../uuid.dart';
 
 class TreeViewDragImage {
   ImageElement image;

--- a/ide/app/lib/uuid.dart
+++ b/ide/app/lib/uuid.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark.uuid;
+
+int _next_id = 0;
+
+/**
+ * A temporary version of the Uuid class from package:uuid. The current version
+ * specifies older versions of the `unittest` and `cipher` library then we want
+ * to use.
+ */
+class Uuid {
+  String v4() => '_uuid_${_next_id++}';
+}

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   spark_widgets:
     path: ../widgets
   unittest: '>=0.10.0'
-  uuid: any
 dev_dependencies:
   args: any
   grinder: '>=0.5.0 <0.6.0'


### PR DESCRIPTION
Change to using a custom Uuid class, not the one from package:uuid. This is a temporary change; once they've updated they're version constraints to use newer versions of unittest and cipher we can switch back.

@dinhviethoa, @shepheb
