### PR TITLE
ui changes to the properties dialog

### DIFF
--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -476,11 +476,9 @@
     <spark-modal id="projectPropertiesDialog" class="dialog spark-overlay-scale-slideup">
       <div class="modal-header">
         <a href="#" class="close" overlay-toggle>&times;</a>
-        <h4 class="modal-title">Project Properties</h4>
+        <h4 class="modal-title">Properties</h4>
       </div>
       <div class="modal-body">
-        <div id="properties" class="form-group">
-        </div>
       </div>
       <div class="modal-footer">
         <spark-button overlay-toggle primary autofocus data-dismiss="modal">


### PR DESCRIPTION
Some tweaks to the Properties dialog:
- renamed to `Properties...`, so it can be made a bit more generic in the future
- re-ordered the context menu items, to clean that menu up a bit
- used some bootstrap css to make the dialog look closer to the rest of the ones in Spark
- used a future to delay showing the dialog until its information is fully populated

@sunglim

![screen shot 2014-02-18 at 4 15 09 pm](https://f.cloud.github.com/assets/1269969/2202119/492c050c-98fb-11e3-8e53-0b7925c5b3ff.png)
