### PR TITLE
Service organization ideas

### DIFF
--- a/ide/app/lib/services/analyzer_service.dart
+++ b/ide/app/lib/services/analyzer_service.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark.services_impl.analyzer;
+
+import "dart:async";
+
+import "../../services_impl.dart";
+import '../analyzer.dart';
+import '../utils.dart';
+
+class AnalyzerServiceImpl extends ServiceImpl {
+  AnalyzerServiceImpl(ServicesIsolate isolate) : super(isolate);
+
+  Future<ServiceActionEvent> handleEvent(ServiceActionEvent event) {
+
+  }
+}
+
+// Used to avoid 'print hidden' warning
+void print(var message) => sendPrint(message);

--- a/ide/app/lib/services/compiler_service.dart
+++ b/ide/app/lib/services/compiler_service.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark.services_impl.compiler;
+
+import "dart:async";
+
+
+import '../dart/sdk.dart';
+import "../../services_impl.dart";
+import 'compiler.dart';
+import '../utils.dart';
+
+class CompilerServiceImpl extends ServiceImpl {
+  String get serviceId => "compiler";
+
+  DartSdk sdk;
+  Compiler compiler;
+
+  Completer<ServiceActionEvent> _readyCompleter =
+      new Completer<ServiceActionEvent>();
+
+  Future<ServiceActionEvent> get onceReady => _readyCompleter.future;
+
+  CompilerServiceImpl(ServicesIsolate isolate) : super(isolate);
+
+  Future<ServiceActionEvent> handleEvent(ServiceActionEvent event) {
+    switch (event.actionId) {
+      case "start":
+        // TODO(ericarnold): Start should happen automatically on use.
+        return _start().then((_) => new Future.value(event.createReponse(null)));
+        break;
+      case "dispose":
+        return new Future.value(event.createReponse(null));
+        break;
+      case "compileString":
+        return compiler.compileString(event.data['string'])
+            .then((CompilerResult result)  {
+              return new Future.value(event.createReponse(result.toMap()));
+            });
+        break;
+      default:
+        throw "Unknown action '${event.actionId}' sent to $serviceId service.";
+    }
+  }
+
+  Future _start() {
+    _isolate.chromeService.getAppContents('sdk/dart-sdk.bin').then((List<int> sdkContents) {
+      sdk = DartSdk.createSdkFromContents(sdkContents);
+      compiler = Compiler.createCompilerFrom(sdk);
+      _readyCompleter.complete();
+    }).catchError((error){
+      // TODO(ericarnold): Return error which service will throw
+      print("Chrome service error: $error ${error.stackTrace}");
+    });
+
+    return _readyCompleter.future;
+  }
+}
+
+
+// Used to avoid 'print hidden' warning
+void print(var message) => sendPrint(message);


### PR DESCRIPTION
Moved compiler into its own file, handled print warnings.

@devoncarew, wanted get your thoughts on service organization.  I started separating services into their own files while starting on analyzer service.  After doing this, I realized that _isolate is no longer accessible (from ServiceImpl), so I'm probably not going to go through with it.  Perhaps each service lives with ServiceImpl in service_impl.dart and the service implementations can live in their own files, referenced by those classes?
