### PR TITLE
fix error while setting initial project location

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -700,7 +700,7 @@ class ProjectLocationManager {
 
       _projectLocation = new LocationResult(entry, entry, false);
       _prefs.setValue('projectFolder', chrome.fileSystem.retainEntry(entry));
-      return new LocationResult(entry, entry, false);
+      return _projectLocation;
     });
   }
 


### PR DESCRIPTION
`_projectLocation` is `LocationResult` .  but `entry` is `CrDirectoryEntry`. 
so there's error when doing `git cloning` at the first time.

review @devoncarew

TEST=Remove all the preference data -> git clone.
