### PR TITLE
fix an issue w/ sizing of the ace editor; delay hiding the splash screen

### DIFF
--- a/ide/app/lib/editor_area.dart
+++ b/ide/app/lib/editor_area.dart
@@ -100,7 +100,8 @@ class EditorArea extends TabView {
     onClose.listen((EditorTab tab) => closeFile(tab.file));
     this.allowsLabelBar = allowsLabelBar;
     showLabelBar = false;
-
+    onLabelBarShown.listen((_) => resize());
+    
     _workspace.onResourceChange.listen((ResourceChangeEvent event) {
       for (ChangeDelta delta in event.changes) {
         if (delta.isDelete && delta.resource.isFile) {

--- a/ide/app/lib/editors.dart
+++ b/ide/app/lib/editors.dart
@@ -19,7 +19,7 @@ import 'workspace.dart';
 import 'ui/widgets/imageviewer.dart';
 
 // The auto-save delay - the time from the last user edit to the file auto-save.
-final int _DELAY_MS = 500;
+final int _DELAY_MS = 1000;
 
 /**
  * Classes implement this interface provides/refreshes editors for [Resource]s.

--- a/ide/app/lib/ui/widgets/tabview.dart
+++ b/ide/app/lib/ui/widgets/tabview.dart
@@ -121,14 +121,16 @@ class TabView {
   DivElement _tabBarScroller;
   DivElement _tabBarScrollable;
   DivElement _tabViewWorkspace;
-
+  bool _labelBarShowing = false;
+  
   StreamController<Tab> _onCloseStreamController =
       new StreamController<Tab>.broadcast(sync: true);
   StreamController<TabBeforeCloseEvent> _onBeforeCloseStreamController =
       new StreamController<TabBeforeCloseEvent>.broadcast(sync: true);
   StreamController<Tab> _onSelectedStreamController =
       new StreamController<Tab>.broadcast(sync: true);
-
+  StreamController<bool> _onLabelBarShown = new StreamController.broadcast();
+  
   final List<Tab> tabs = new List<Tab>();
   Tab _selectedTab;
   bool _tabItemsLayoutListenerEnabled = false;
@@ -146,6 +148,12 @@ class TabView {
         e.preventDefault();
         e.stopPropagation();
         _tabBarScroller.scrollLeft +=  e.deltaX.round();
+      }
+    });
+    _tabBar.onTransitionEnd.listen((_) {
+      if (showLabelBar != _labelBarShowing) {
+        _labelBarShowing = showLabelBar;
+        _onLabelBarShown.add(_labelBarShowing);
       }
     });
     _tabBarScrollable = new DivElement()
@@ -167,9 +175,7 @@ class TabView {
       }
     });
 
-    window.onResize.listen((e) {
-      _layoutTabItemsOnResize();
-    });
+    window.onResize.listen((e) => _layoutTabItemsOnResize());
   }
 
   Tab get selectedTab => _selectedTab;
@@ -341,4 +347,5 @@ class TabView {
   Stream<TabBeforeCloseEvent> get onBeforeClose =>
       _onBeforeCloseStreamController.stream;
   Stream<Tab> get onSelected => _onSelectedStreamController.stream;
+  Stream<bool> get onLabelBarShown => _onLabelBarShown.stream;
 }

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -472,6 +472,9 @@ class Spark extends SparkModel implements FilesControllerDelegate,
     showErrorMessage(title, message);
   }
 
+    // Implemented in a sub-class.
+  void unveil() { }
+
   /**
    * Show a model error dialog.
    */
@@ -799,7 +802,7 @@ class _SparkSetupParticipant extends LifecycleParticipant {
     // get platform info
     return chrome.runtime.getPlatformInfo().then((Map m) {
       spark._platformInfo = new PlatformInfo._(m['os'], m['arch'], m['nacl_arch']);
-      spark.workspace.restore().then((value) {
+      return spark.workspace.restore().then((value) {
         if (spark.workspace.getFiles().length == 0) {
           // No files, just focus the editor.
           spark.aceManager.focus();
@@ -809,7 +812,7 @@ class _SparkSetupParticipant extends LifecycleParticipant {
       return ProjectLocationManager.restoreManager(spark.localPrefs).then((manager) {
         spark.projectLocationManager = manager;
       });
-    });
+    }).whenComplete(() => spark.unveil());
   }
 
   Future applicationStarted(Application application) {

--- a/ide/app/spark_model.dart
+++ b/ide/app/spark_model.dart
@@ -41,4 +41,9 @@ abstract class SparkModel extends Application {
 
   void onSplitViewUpdate(int position);
   void setGitSettingsResetDoneVisible(bool visible);
+
+  /**
+   * Hide the splash screen; show the main UI.
+   */
+  void unveil();
 }

--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -86,13 +86,6 @@ class SparkPolymer extends Spark {
       : _ui = document.querySelector('#topUi') as SparkPolymerUI,
         super(developerMode) {
     _ui.developerMode = developerMode;
-
-    // Prevent FOUC in our own way. Polymer recommended ways don't work
-    // (bug pending).
-    polymer.Polymer.onReady.then((_) {
-      // BUG: Without this delay, FOUC still happens. Probably a Polymer bug.
-      new Timer(new Duration(milliseconds: 500), unveil);
-    });
   }
 
   @override


### PR DESCRIPTION
Fix an issue w/ the ace editor not being sized properly when tabs changed between showing and not showing states. We need to re-size the editor when it's vertical height changes.

Also, move to hiding the splash screen when more of the app is ready. We now wait until after the workspace is restored. Before we waited until after polymer was ready. This prevented FOUC but left the components empty until the app was loaded.

@dinhviethoa @ussuri
