### PR TITLE
update package:chrome; listen for window close events

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -137,9 +137,10 @@ class Spark extends SparkModel implements FilesControllerDelegate,
 
     addParticipant(new _SparkSetupParticipant(this));
 
-    // TODO: this event is not being fired. A bug with chrome apps / Dartium?
-    // Possibly this: https://github.com/dart-gde/chrome.dart/issues/115
-    chrome.app.window.onClosed.listen((_) {
+    // This event is not fired when closing the current window. We listen for it
+    // in the vain hope that we will get the event, and we'll be able to clean
+    // up after ourselves slightly better.
+    chrome.app.window.current().onClosed.listen((_) {
       close();
     });
 
@@ -1534,9 +1535,9 @@ class _HarnessPushJob extends Job {
   _HarnessPushJob(this.spark, this.deployContainer, this._url) :
     super('Deploying to mobile…');
 
-  Future run(ProgressMonitor monitor) {    
+  Future run(ProgressMonitor monitor) {
     HarnessPush harnessPush = new HarnessPush(deployContainer);
-    
+
     return harnessPush.push(_url, monitor).then((_) {
       spark.showSuccessMessage('Successfully pushed');
     }).catchError((e) {

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   archive: '>=1.0.15 <1.1.0'
   bootjack: any
   browser: any
-  chrome: '>=0.5.0 <0.6.0'
+  chrome: '>=0.5.1 <0.6.0'
   cipher: '>=0.5.0 <0.6.0'
   compiler_unsupported: 0.7.0
   crypto: any


### PR DESCRIPTION
Address the window close issue, in as much as we can. package:chrome has been patched to listen for window events on the right object. We had to add a way to manually override the code generated from the idl.

Our code's been updated to listen on the window object. @ussuri
