### PR TITLE
upgrade our dependency on uuid

### DIFF
--- a/ide/app/lib/ui/widgets/treeview.dart
+++ b/ide/app/lib/ui/widgets/treeview.dart
@@ -11,7 +11,7 @@ library spark.ui.widgets.treeview;
 import 'dart:collection';
 import 'dart:html';
 
-import 'package:uuid/uuid.dart';
+import 'package:uuid/uuid_client.dart';
 
 import 'treeview_cell.dart';
 import 'treeview_row.dart';

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   bootjack: any
   browser: any
   chrome: '>=0.5.1 <0.6.0'
-  cipher: '>=0.5.0 <0.6.0'
+  cipher: '>=0.6.0 <0.7.0'
   compiler_unsupported: 0.7.0
   crypto: any
   dquery: '>=0.5.0 <0.6.0'
@@ -27,7 +27,7 @@ dependencies:
   tavern:
     git: git://github.com/tapted/tavern.git
   unittest: '>=0.10.0'
-  uuid: any
+  uuid: '>=0.3.0 <0.4.0'
 dev_dependencies:
   args: any
   grinder: '>=0.5.0 <0.6.0'


### PR DESCRIPTION
Upgrade our dependency on uuid to 0.3.0. This version has updated its dependency on cipher, so we can use the latest of both packages together w/o issues.

@dinhviethoa, @shepheb
