### PR TITLE
add reflectable to object used in html page

### DIFF
--- a/ide/app/lib/scm.dart
+++ b/ide/app/lib/scm.dart
@@ -13,6 +13,7 @@ import 'dart:async';
 import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
+import 'package:observe/observe.dart';
 
 import 'builder.dart';
 import 'jobs.dart';
@@ -211,6 +212,7 @@ class FileStatus {
 /**
  * The SCM commit information.
  */
+@reflectable
 class CommitInfo {
   String identifier;
   String authorName;


### PR DESCRIPTION
The push dialog doesn't work when compiled to javascript. From the exceptions, the `CommitInfo` object doesn't have any of the fields that the polymer UI is trying to access on it (`message`, `identifier`, ...). I think dart2js is mangling the field names.

As a policy, we should always add `@observable` or `@reflectable` to anything accessed via html.

@dinhviethoa, @ussuri
