### PR TITLE
spark-splitter: switch from passing in external event handlers to firing custom events

### DIFF
--- a/ide/app/spark_polymer_ui.dart
+++ b/ide/app/spark_polymer_ui.dart
@@ -53,8 +53,8 @@ class SparkPolymerUI extends SparkWidget {
     SparkModel.instance.aceKeysManager.inc(e);
   }
 
-  void onSplitterUpdate(int position) {
-    SparkModel.instance.onSplitViewUpdate(position);
+  void onSplitterUpdate(CustomEvent e, var detail) {
+    SparkModel.instance.onSplitViewUpdate(detail['targetSize']);
   }
 
   void bindKeybindingDesc() {

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -80,7 +80,7 @@
     <spark-split-view
         id="splitView"
         direction="left" splitterSize="6" splitterHandle="false"
-        onUpdate="{{onSplitterUpdate}}">
+        on-update="{{onSplitterUpdate}}">
       <content></content>
     </spark-split-view>
 

--- a/widgets/lib/spark_split_view/spark_split_view.dart
+++ b/widgets/lib/spark_split_view/spark_split_view.dart
@@ -19,7 +19,6 @@ class SparkSplitView extends SparkWidget {
   @published int splitterSize = 8;
   @published bool splitterHandle = true;
   @published bool locked = false;
-  @published SplitterUpdateFunction onUpdate;
 
   /// Constructor.
   SparkSplitView.created() : super.created();
@@ -45,5 +44,13 @@ class SparkSplitView extends SparkWidget {
    */
   set targetSize(num val) {
     ($['splitter'] as SparkSplitter).targetSize = val;
+  }
+
+  /**
+   * Re-fire an update event from the splitter for explicitness.
+   */
+  void splitterUpdateHandler(CustomEvent e, var detail) {
+    e..stopImmediatePropagation()..preventDefault();
+    asyncFire('update', detail: detail);
   }
 }

--- a/widgets/lib/spark_split_view/spark_split_view.html
+++ b/widgets/lib/spark_split_view/spark_split_view.html
@@ -32,7 +32,7 @@
 <link rel="import" href="../../../packages/spark_widgets/spark_splitter/spark_splitter.html"/>
 
 <polymer-element name="spark-split-view" extends="spark-widget"
-    attributes="direction splitterSize splitterHandle locked onUpdate">
+    attributes="direction splitterSize splitterHandle locked">
   <template>
     <!-- BUG: https://code.google.com/p/dart/issues/detail?id=14382 -->
     <!-- link rel="stylesheet" href="xyz.css" -->
@@ -48,7 +48,7 @@
         size="{{splitterSize}}"
         handle="{{splitterHandle}}"
         locked="{{locked}}"
-        onUpdate="{{onUpdate}}">
+        on-update="{{splitterUpdateHandler}}">
     </spark-splitter>
     <content select=":nth-child(2)"></content>
   </template>

--- a/widgets/lib/spark_splitter/spark_splitter.dart
+++ b/widgets/lib/spark_splitter/spark_splitter.dart
@@ -11,8 +11,6 @@ import 'package:polymer/polymer.dart';
 
 import '../common/spark_widget.dart';
 
-typedef void SplitterUpdateFunction(int position);
-
 @CustomTag('spark-splitter')
 class SparkSplitter extends SparkWidget {
   /// Possible values are "left", "right", "up" and "down".
@@ -27,8 +25,6 @@ class SparkSplitter extends SparkWidget {
   @published bool handle = true;
   /// Whether to lock the split bar so it can't be dragged.
   @published bool locked = false;
-  /// Get notified of position changes.
-  @published SplitterUpdateFunction onUpdate;
 
   /**
    * Return the current splitter location.
@@ -190,7 +186,7 @@ class SparkSplitter extends SparkWidget {
     _trackEndSubscr.cancel();
     _trackEndSubscr = null;
 
-    if (onUpdate != null) onUpdate(_targetSize);
+    asyncFire('update', detail: {'targetSize': _targetSize});
 
     // Prevent possible wrong use of the cached value.
     _targetSize = null;

--- a/widgets/lib/spark_splitter/spark_splitter.html
+++ b/widgets/lib/spark_splitter/spark_splitter.html
@@ -33,7 +33,7 @@
 <link rel="import" href="../../../packages/spark_widgets/common/spark_widget.html"/>
 
 <polymer-element name="spark-splitter" extends="spark-widget"
-    attributes="direction size handle locked onUpdate">
+    attributes="direction size handle locked">
   <template>
     <!-- BUG: https://code.google.com/p/dart/issues/detail?id=14382 -->
     <!-- link rel="stylesheet" href="xyz.css" -->


### PR DESCRIPTION
TBR @devoncarew

This is a more proper Polymer way of communicating changes to the client, which also indirectly fixes the warning reported by the linter about the onUpdate attribute's name.

Fixes #643.
