### PR TITLE
several fixes and performance improvements

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -30,6 +30,7 @@ class TextEditor extends Editor {
 
   StreamSubscription _aceSubscription;
   StreamController _dirtyController = new StreamController.broadcast();
+  StreamController _modificationController = new StreamController.broadcast();
 
   ace.EditSession _session;
 
@@ -47,12 +48,14 @@ class TextEditor extends Editor {
   bool get dirty => _dirty;
 
   Stream get onDirtyChange => _dirtyController.stream;
+  Stream get onModification => _modificationController.stream;
 
   set dirty(bool value) {
     if (value != _dirty) {
       _dirty = value;
       _dirtyController.add(value);
     }
+    _modificationController.add(dirty);
   }
 
   html.Element get element => aceManager.parentElement;

--- a/ide/app/lib/editors.dart
+++ b/ide/app/lib/editors.dart
@@ -45,6 +45,7 @@ abstract class Editor {
   bool get dirty;
 
   Stream get onDirtyChange;
+  Stream get onModification;
 
   void activate();
   void resize();
@@ -282,7 +283,6 @@ class EditorManager implements EditorProvider {
     _eventBus.addEvent('fileModified', currentFile);
 
     if (_timer != null) _timer.cancel();
-
     _timer = new Timer(new Duration(milliseconds: _DELAY_MS), () => _saveAll());
   }
 
@@ -363,9 +363,7 @@ class EditorManager implements EditorProvider {
 
     _editorMap[file] = editor;
     openFile(file);
-    editor.onDirtyChange.listen((_) {
-      if (editor.dirty) _startSaveTimer();
-    });
+    editor.onModification.listen((_) => _startSaveTimer());
     return editor;
   }
 

--- a/ide/app/lib/git/commands/index.dart
+++ b/ide/app/lib/git/commands/index.dart
@@ -206,6 +206,10 @@ class FileStatus {
   String headSha;
   String sha;
   int size;
+
+  /**
+   * The number of milliseconds since the Unix epoch.
+   */
   int modificationTime;
 
   /**

--- a/ide/app/lib/git/commands/revert.dart
+++ b/ide/app/lib/git/commands/revert.dart
@@ -17,14 +17,12 @@ import 'status.dart';
  * Reverts a given list of file entries to the git head state.
  */
 class Revert {
-  static Future revert(GitOptions options, List<chrome.ChromeFileEntry>
-      entries) {
+  static Future revert(GitOptions options, List<chrome.FileEntry> entries) {
     return Future.forEach(entries, (entry) {
-      return Status.getFileStatus(options.store, entry).then(
-          (FileStatus status) {
+      return Status.getFileStatus(options.store, entry).then((FileStatus status) {
         return options.store.retrieveObjectBlobsAsString([status.headSha]).then(
             (List<LooseObject> objects) {
-          return entry.writeText(objects.first.data);
+          return (entry as chrome.ChromeFileEntry).writeText(objects.first.data);
         });
       });
     });

--- a/ide/app/lib/git/commands/status.dart
+++ b/ide/app/lib/git/commands/status.dart
@@ -29,9 +29,10 @@ class Status {
    */
   static Future<FileStatus> getFileStatus(ObjectStore store,
       chrome.ChromeFileEntry entry) {
-    return entry.getMetadata().then((data) {
+    return entry.getMetadata().then((chrome.Metadata data) {
       FileStatus status = store.index.getStatusForEntry(entry);
-      if (status != null && status.modificationTime == data.modificationTime) {
+      if (status != null &&
+          status.modificationTime == data.modificationTime.millisecondsSinceEpoch) {
         // Unchanged file since last update.
         return status;
       }
@@ -42,7 +43,7 @@ class Status {
         status.path = entry.fullPath;
         status.sha = sha;
         status.size = data.size;
-        status.modificationTime = data.modificationTime;
+        status.modificationTime = data.modificationTime.millisecondsSinceEpoch;
         store.index.updateIndexForEntry(status);
         return store.index.getStatusForEntry(entry);
       });

--- a/ide/app/lib/ui/widgets/imageviewer.dart
+++ b/ide/app/lib/ui/widgets/imageviewer.dart
@@ -206,6 +206,7 @@ class ImageViewer implements Editor {
 
   StreamController _dirtyController = new StreamController.broadcast();
   Stream get onDirtyChange => _dirtyController.stream;
+  Stream get onModification => _dirtyController.stream;
   bool get dirty => false;
   Future save() {
     return new Future.value();

--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -660,15 +660,15 @@ class Folder extends Container {
       }
 
       // Check for modified files.
-      return Future.forEach(checkChanged, (Resource resource) {
+      futures.addAll(checkChanged.map((Resource resource) {
         if (resource is File) {
           return resource._refresh();
         } else if (resource is Folder) {
           return resource._refresh();
         }
-      }).then((_) {
-        return Future.wait(futures);
-      });
+      }));
+
+      return Future.wait(futures);
     });
   }
 
@@ -691,6 +691,10 @@ class File extends Resource {
 
   Future setContents(String contents) {
     return _fileEntry.writeText(contents).then((_) {
+      return entry.getMetadata();
+    }).then((/*Metadata*/ metaData) {
+      _timestamp = metaData.modificationTime.millisecondsSinceEpoch;
+    }).then((_) {
       workspace._fireResourceEvent(new ChangeDelta(this, EventType.CHANGE));
     });
   }
@@ -862,7 +866,7 @@ class FileRoot extends WorkspaceRoot {
       'token': token
     };
   }
-  
+
   String toString() => "FileRoot ${id}";
 }
 
@@ -899,7 +903,7 @@ class FolderRoot extends WorkspaceRoot {
       'token': token
     };
   }
-  
+
   String toString() => "FolderRoot ${id}";
 }
 
@@ -941,7 +945,7 @@ class FolderChildRoot extends WorkspaceRoot {
       'name': name
     };
   }
-  
+
   String toString() => "FolderChildRoot ${parentToken} / ${name}";
 }
 
@@ -962,7 +966,7 @@ class SyncFolderRoot extends WorkspaceRoot {
 
   // We do not persist infomation about the sync filesystem root.
   Map persistState() => null;
-  
+
   String toString() => "SyncFolderRoot ${entry.name}";
 }
 

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -49,15 +49,6 @@ import 'spark_model.dart';
 
 analytics.Tracker _analyticsTracker = new analytics.NullTracker();
 
-void main() {
-  isTestMode().then((testMode) {
-    createSparkZone().runGuarded(() {
-      Spark spark = new Spark(testMode);
-      spark.start();
-    });
-  });
-}
-
 /**
  * Returns true if app.json contains a test-mode entry set to true. If app.json
  * does not exit, it returns true.
@@ -128,7 +119,6 @@ class Spark extends SparkModel implements FilesControllerDelegate,
       ['.cmake', '.gitignore', '.lock', '.prefs', '.txt']);
 
   Spark(this.developerMode) {
-
     document.title = appName;
 
     _localPrefs = preferences.localStore;
@@ -252,20 +242,22 @@ class Spark extends SparkModel implements FilesControllerDelegate,
   //
 
   void initAnalytics() {
+    // Init the analytics tracker and send a page view for the main page.
     analytics.getService('Spark').then((service) {
-      // Init the analytics tracker and send a page view for the main page.
       _analyticsTracker = service.getTracker(_ANALYTICS_ID);
       _analyticsTracker.sendAppView('main');
+    });
 
-      // Track logged exceptions.
-      Logger.root.onRecord.listen((LogRecord r) {
-        if (r.loggerName != 'spark.tests') {
-          print(r.toString() + (r.error != null ? ', ${r.error}' : ''));
-          if (r.level >= Level.SEVERE) {
-            _handleUncaughtException(r.error, r.stackTrace);
-          }
-        }
-      });
+    // Track logged exceptions.
+    Logger.root.onRecord.listen((LogRecord r) {
+      if (r.loggerName == 'spark.tests') return;
+      if (!developerMode && r.level <= Level.INFO) return;
+
+      print(r.toString() + (r.error != null ? ', ${r.error}' : ''));
+
+      if (r.level >= Level.SEVERE) {
+        _handleUncaughtException(r.error, r.stackTrace);
+      }
     });
   }
 

--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -22,10 +22,16 @@ import 'lib/jobs.dart';
 void main() {
   isTestMode().then((testMode) {
     polymer.initPolymer().run(() {
-      createSparkZone().runGuarded(() {
+      // Don't set up the zone exception handler if we're running in dev mode.
+      if (testMode) {
         SparkPolymer spark = new SparkPolymer._(testMode);
         spark.start();
-      });
+      } else {
+        createSparkZone().runGuarded(() {
+          SparkPolymer spark = new SparkPolymer._(testMode);
+          spark.start();
+        });
+      }
     });
   });
 }

--- a/ide/app/test/ace_test.dart
+++ b/ide/app/test/ace_test.dart
@@ -70,6 +70,7 @@ class MockAceEditor implements TextEditor {
   set dirty(bool value) { }
 
   Stream get onDirtyChange => null;
+  Stream get onModification => null;
 
   Future save() => new Future.value();
 


### PR DESCRIPTION
Several fixes, performance improvements, and added logging:
- editors now report when they're modified (as well as when they're dirtied). This lets us listen for modifications, and only auto-save an editor once it's been ~1 seconds since it was last modified. Before, we saved every second, even if the user was still typing
- added logging info for builds, jobs, and scm status
- fixed some checked mode issues in git, including a `modificationTime` assignment issue
- made project refresh twice as fast, by waiting on the futures in parallel, instead of sequentially
- changed our exception catcher to not catch when running in developer mode
- we don't emit info level log messages if not running in dev mode
- fixed an issue where modifying a workspace resource would fire two change events
- changed scm status to not request status for files in the `.git` folder (like the index file)

Sorry for the un-focused nature of this CL - was fixing issues as I ran into them.

@sunglim and @gaurave for review
