### PR TITLE
size the search box to be the same size as the search results; exclude r...

### DIFF
--- a/ide/app/spark_polymer_ui.css
+++ b/ide/app/spark_polymer_ui.css
@@ -6,7 +6,6 @@
 
 #searchBox {
   display: inline-block;
-  width: 250px;
   position: relative;
   top: 4px;
 }

--- a/widgets/lib/spark_suggest/spark_suggest_box.css
+++ b/widgets/lib/spark_suggest/spark_suggest_box.css
@@ -6,6 +6,7 @@
 
 #text-box {
   height: 31px;
+  width: 350px;
 }
 
 #suggestion-list-overlay {
@@ -13,26 +14,26 @@
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 3px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  margin-left: 55px;
-  margin-top: 12px;
+  margin-top: 7px;
   padding: 5px 0;
-  width: 400px;
+  width: 350px;
   max-height: 350px;
   overflow-y: scroll;
-  -webkit-transform: translateX(-50%);
-  transform: translateX(-50%);
+  overflow-x: hidden;
 }
 
 #suggestion-list-menu {
   border: none;
   display: block;
   box-sizing: border-box;
-  margin: 5px 0;
+  margin: 0 0;
 }
 
 .suggestion-item {
-  padding: 7px 20px;
+  padding: 7px 12px;
   font-size: 14px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .suggestion-item[active] {
@@ -42,6 +43,4 @@
 
 .text-muted {
   color: #bdbdbd;
-  float: right;
-  overflow: hidden;
 }


### PR DESCRIPTION
Search improvements:
- ignore 'derived' resources in the search results. this includes things from the `build/` directory
- size the search results to be as wide as the search box, and to appear directly under it

![screen shot 2014-03-02 at 2 26 59 am](https://f.cloud.github.com/assets/1269969/2312065/518f8ede-a2f7-11e3-9e7f-35634c266c2b.png)

@ussuri
