### PR TITLE
ADB support for Deploy

### DIFF
--- a/ide/app/lib/adb.dart
+++ b/ide/app/lib/adb.dart
@@ -1,0 +1,686 @@
+// Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library spark.adb;
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bignum/bignum.dart';
+import 'package:chrome/chrome_app.dart' as chrome;
+import 'package:cipher/cipher.dart';
+import 'package:cipher/impl/base.dart' as CipherBase;
+import 'package:crypto/crypto.dart' show CryptoUtils;
+
+import 'preferences.dart';
+
+// Most of these are helper classes that don't really need to be exported,
+// and might be better off in an internal library.
+class AdbUtil {
+  // ADB command names
+  static final int A_SYNC = 0x434e5953;
+  static final int A_CNXN = 0x4e584e43;
+  static final int A_OPEN = 0x4e45504f;
+  static final int A_OKAY = 0x59414b4f;
+  static final int A_CLSE = 0x45534c43;
+  static final int A_WRTE = 0x45545257;
+  static final int A_AUTH = 0x48545541;
+
+  // ADB protocol version
+  static final int A_VERSION = 0x01000000;
+
+  static final int MESSAGE_SIZE_PAYLOAD = 24;
+  static final int MAX_PAYLOAD = 4096;
+  static final int ADB_VERSION_MINOR = 0; // Used for help/version info.
+
+  // Increment this when we want to force users to start a new ADB server.
+  static final int ADB_SERVER_VERSION = 31;
+
+  // USB information
+  static final int ADB_CLASS = 0xff;
+  static final int ADB_SUBCLASS = 0x42;
+  static final int ADB_PROTOCOL = 0x1;
+
+  // Types for AUTH commands
+  static final int ADB_AUTH_TOKEN = 1;
+  static final int ADB_AUTH_SIGNATURE = 2;
+  static final int ADB_AUTH_RSAPUBLICKEY = 3;
+
+  // Some helper functions.
+  static int checksum(ByteData data) {
+    int result = 0;
+    var buffer = new Uint8List.view(data.buffer);
+    for (int i = 0; i < buffer.length; i++) {
+      int x = buffer[i];
+      if (x < 0) {
+        x += 256;
+      }
+      result += x;
+    }
+    return result;
+  }
+}
+
+class SystemIdentity {
+  // Can be 'host', 'bootloader', 'device'.
+  String systemType = 'host';
+  String serialno = '';
+  String banner = '';
+  String toString() => '${systemType}:${serialno}:${banner}';
+}
+
+class AdbMessage {
+  static final int _COMMAND_OFFSET = 0;
+  static final int _ARG0_OFFSET = 4;
+  static final int _ARG1_OFFSET = 8;
+  static final int _DATA_LENGTH_OFFSET = 12;
+  static final int _CHECKSUM_OFFSET = 16;
+  static final int _MAGIC_OFFSET = 20;
+
+  ByteData messageBuffer = new ByteData(AdbUtil.MESSAGE_SIZE_PAYLOAD);
+  ByteData dataBuffer;
+
+  int _getInt32(offset) =>
+      messageBuffer.getInt32(offset, Endianness.LITTLE_ENDIAN);
+
+  void _setInt32(offset, value) =>
+      messageBuffer.setInt32(offset, value, Endianness.LITTLE_ENDIAN);
+
+  /*
+  struct message {
+    unsigned command;       // command identifier constant
+    unsigned arg0;          // first argument
+    unsigned arg1;          // second argument
+    unsigned data_length;   // length of payload (0 is allowed)
+    unsigned data_crc32;    // crc32 of data payload
+    unsigned magic;         // command ^ 0xffffffff
+  };
+  */
+  int  get command => _getInt32(_COMMAND_OFFSET);
+  void set command(int value) => _setInt32(_COMMAND_OFFSET, value);
+  int  get arg0 => _getInt32(_ARG0_OFFSET);
+  void set arg0(int value) => _setInt32(_ARG0_OFFSET, value);
+  int  get arg1 => _getInt32(_ARG1_OFFSET);
+  void set arg1(int value) => _setInt32(_ARG1_OFFSET, value);
+  int  get dataLength => _getInt32(_DATA_LENGTH_OFFSET);
+  void set dataLength(int value) => _setInt32(_DATA_LENGTH_OFFSET, value);
+  int  get dataCrc32 => _getInt32(_CHECKSUM_OFFSET);
+  void set dataCrc32(int value) => _setInt32(_CHECKSUM_OFFSET, value);
+  int  get magic => _getInt32(_MAGIC_OFFSET);
+  void set magic(int value) => _setInt32(_MAGIC_OFFSET, value);
+
+  AdbMessage(int command, int arg0, int arg1, [String data = null]) {
+    if (data != null) {
+      // Build a dataBuffer.
+      dataBuffer = new ByteData(data.length);
+      Uint8List u8data = new Uint8List.fromList(data.codeUnits);
+      Uint8List u8DataBufferView = new Uint8List.view(dataBuffer.buffer);
+      for (int i = 0; i < u8data.length; i++) {
+        u8DataBufferView[i] = u8data[i];
+      }
+    }
+
+    this.command = command;
+    this.arg0 = arg0;
+    this.arg1 = arg1;
+    this.dataLength = data != null ? data.length : 0;
+    this.dataCrc32 = data != null ? AdbUtil.checksum(dataBuffer) : 0;
+    this.magic = command ^ 0xffffffff;
+  }
+
+  AdbMessage.fromMessageBufferBytes(List<int> bytes) {
+    Uint8List u8data = new Uint8List.fromList(bytes);
+    Uint8List u8MessageBufferView = new Uint8List.view(messageBuffer.buffer);
+    for (int i = 0; i < u8data.length; i++) {
+      u8MessageBufferView[i] = u8data[i];
+    }
+  }
+
+  // Read into dataBuffer.
+  // To be used on receiving the data of an incoming message.
+  void loadDataBuffer(List<int> data) {
+    // Rely on the messageBuffer's information.
+    dataBuffer = new ByteData(dataLength);
+    Uint8List u8data = new Uint8List.fromList(data);
+    Uint8List u8DataBufferView = new Uint8List.view(dataBuffer.buffer);
+    for (int i = 0; i < u8data.length; i++) {
+      u8DataBufferView[i] = u8data[i];
+    }
+  }
+
+  // To be used on freshly created messages, that don't have their length or crc
+  // fields set yet.
+  void setData(ByteData data) {
+    dataBuffer = new ByteData(data.lengthInBytes);
+    Uint8List u8data = new Uint8List.view(data.buffer);
+    Uint8List u8DataBufferView = new Uint8List.view(dataBuffer.buffer);
+    for (int i = 0; i < u8data.length; i++) {
+      u8DataBufferView[i] = u8data[i];
+    }
+
+    dataLength = data.lengthInBytes;
+    dataCrc32 = AdbUtil.checksum(data);
+  }
+
+
+  String toString() {
+    StringBuffer sb = new StringBuffer()
+    ..write('[command = ${command.toRadixString(16)}, ')
+    ..write('arg0 = ${arg0.toRadixString(16)}, ')
+    ..write('arg1 = ${arg1.toRadixString(16)}, ')
+    ..write('dataLength = ${dataLength.toRadixString(16)}, ')
+    ..write('dataCrc32 = ${dataCrc32.toRadixString(16)}, ')
+    ..write('magic = ${magic.toRadixString(16)}]');
+
+    if (dataBuffer != null) {
+      sb.write('[');
+      Uint8List u8DataBufferView = new Uint8List.view(dataBuffer.buffer);
+      for (int i = 0; i < u8DataBufferView.length; i++) {
+        if (i + 1 != u8DataBufferView.length) {
+          sb.write('${u8DataBufferView[i].toRadixString(16)}, ');
+        } else {
+          sb.write('${u8DataBufferView[i].toRadixString(16)}]');
+        }
+      }
+    }
+
+    return sb.toString();
+  }
+}
+
+class AndroidDevice {
+  chrome.Device androidDevice;
+  chrome.InterfaceDescriptor adbInterface;
+  chrome.EndpointDescriptor inDescriptor;
+  chrome.EndpointDescriptor outDescriptor;
+  chrome.ConnectionHandle adbConnectionHandle;
+  PreferenceStore _prefs;
+
+  String deviceToken = 'DEVICE TOKEN NOT SET';
+
+  AndroidDevice(this._prefs) {
+    // The cipher library needs initializing before it can be used.
+    // This function is safe to call multiple times.
+    CipherBase.initCipher();
+  }
+
+  Future listDevices() {
+    // TODO (shepheb): List all Android devices.
+  }
+
+  // Either resolves on successful open, or rejects with an error message on failure.
+  Future open(vendorId, productId) {
+    chrome.EnumerateDevicesOptions edo =
+        new chrome.EnumerateDevicesOptions(vendorId: vendorId, productId:
+            productId);
+
+    // Get the devices with the given vendor id and product id.
+    return chrome.usb.getDevices(edo).then((List<chrome.Device> devices) {
+      // For each such device, look for a specific device with ADB class,
+      // subclass and protocol.
+      // TODO(shepheb): Handle finding multiple ADB devices.
+      // NB: The function inside the forEach below uses errors to indicate
+      // success, when it finds a valid device. This is a bit of a hack, but it
+      // works. Real errors are String messages. "Successes" are null.
+      return Future.forEach(devices, (chrome.Device device) {
+        chrome.EnumerateDevicesAndRequestAccessOptions opts =
+            new chrome.EnumerateDevicesAndRequestAccessOptions(
+                vendorId: device.vendorId, productId: device.productId);
+        return chrome.usb.findDevices(opts)
+            .then((List<chrome.ConnectionHandle> connections) {
+              return Future.forEach(connections,
+                  (chrome.ConnectionHandle handle) {
+                    return _checkDevice(handle, device);
+                  });
+            });
+      }).then((_) {
+        // If the above completed "successfully", then no device was found.
+        return new Future.error('No Android device found.');
+      }).catchError((e) {
+        if (e == null || e is NullThrownError) {
+          // Turn an empty error into an empty success, since we found our
+          // Android device.
+          return null;
+        } else {
+          // Otherwise the error is real, and we should re-throw.
+          return new Future.error(e);
+        }
+      });
+    });
+  }
+
+  // Returns an Error future when it finds a valid device. This is part of the
+  // flow of open() above.
+  Future _checkDevice(chrome.ConnectionHandle handle, chrome.Device device) {
+    // List all interfaces on this connection handle.
+    return chrome.usb.listInterfaces(handle)
+        .then((List<chrome.InterfaceDescriptor> interfaces) {
+          // For each interface, find the match for ADB class, subclass and
+          // protocol.
+          interfaces.forEach((interface) {
+            // Check to make sure interface class, subclass and protocol
+            // match ADB.
+            // Avoid opening mass storage endpoints (they're slow).
+            if (interface.interfaceClass == AdbUtil.ADB_CLASS &&
+                interface.interfaceSubclass == AdbUtil.ADB_SUBCLASS &&
+                interface.interfaceProtocol == AdbUtil.ADB_PROTOCOL) {
+              adbInterface = interface;
+              androidDevice = device;
+              this.adbConnectionHandle = handle;
+            }
+
+            interface.endpoints.forEach((chrome.EndpointDescriptor desc) {
+              // Find the input and output descriptors.
+              if (desc.direction == chrome.Direction.IN &&
+                  interface.interfaceClass == AdbUtil.ADB_CLASS &&
+                  interface.interfaceSubclass == AdbUtil.ADB_SUBCLASS &&
+                  interface.interfaceProtocol == AdbUtil.ADB_PROTOCOL) {
+                inDescriptor = desc;
+              } else if (desc.direction == chrome.Direction.OUT &&
+                  interface.interfaceClass == AdbUtil.ADB_CLASS &&
+                  interface.interfaceSubclass == AdbUtil.ADB_SUBCLASS &&
+                  interface.interfaceProtocol == AdbUtil.ADB_PROTOCOL) {
+                outDescriptor = desc;
+              }
+            });
+          });
+
+          // Check if all parts of the device got assigned.
+          if (adbInterface != null && androidDevice != null &&
+              this.adbConnectionHandle != null && inDescriptor != null &&
+              outDescriptor != null) {
+            // Throw here to bail out of iterating through the devices.
+            // It's not really an error.
+            return new Future.error(null);
+          }
+        });
+  }
+
+  // This either resolves with a TransferResultInfo, or fails with an error
+  // message.
+  Future<chrome.TransferResultInfo> sendBuffer(ByteData buffer) {
+    chrome.ArrayBuffer arrayBuffer = new chrome.ArrayBuffer.fromBytes(
+        new Uint8List.view(buffer.buffer).toList());
+
+    chrome.GenericTransferInfo transferInfo = new chrome.GenericTransferInfo()
+        ..direction = outDescriptor.direction
+        ..endpoint = outDescriptor.address
+        ..length = arrayBuffer.getBytes().length
+        ..data = arrayBuffer;
+
+    return chrome.usb.bulkTransfer(adbConnectionHandle, transferInfo)
+        .then((chrome.TransferResultInfo result) {
+      if (result.resultCode != 0) {
+        return new Future.error('Failed to send');
+      } else {
+        return result;
+      }
+    });
+  }
+
+  // Sends both the message and data portions.
+  // The future either resolves with a TransferResultInfo, or fails with an
+  // error message.
+  Future<chrome.TransferResultInfo> sendMessage(AdbMessage message) {
+    return sendBuffer(message.messageBuffer).then(
+        (chrome.TransferResultInfo result) {
+      return message.dataLength > 0 ? sendBuffer(message.dataBuffer) : result;
+    });
+  }
+
+
+  // Connects to and authenticates with the device.
+  Future connect(SystemIdentity systemIdentity) {
+    return chrome.usb.claimInterface(adbConnectionHandle,
+        adbInterface.interfaceNumber).then((_) {
+      AdbMessage adbMessage = new AdbMessage(AdbUtil.A_CNXN, AdbUtil.A_VERSION,
+          AdbUtil.MAX_PAYLOAD, systemIdentity.toString());
+
+      // Transfer connect message.
+      return sendMessage(adbMessage).then((_) {
+        return expectConnectionMessage();
+      });
+    });
+  }
+
+  Future<AsymmetricKeyPair> getKeys(ByteData seedToken) {
+    return _prefs.getValue('adb_rsa_keys').then((jsonKeys) {
+      if (jsonKeys == null) {
+        return new Future.error('catchError below will generate keys');
+      }
+      return _deserializeRSAKeys(jsonKeys);
+    }).catchError((e) {
+      // If we can't retrieve the public and private keys, create and store a
+      // new pair.
+      // ADB uses 2048-bit RSA keys.
+      RSAKeyGeneratorParameters params = new RSAKeyGeneratorParameters(
+          new BigInteger(257), 2048, 90);
+
+      SecureRandom rnd = new SecureRandom('AES/CTR/PRNG');
+      // Using the random token from the device as the seed.
+      ParametersWithIV rndParams = new ParametersWithIV(
+          new KeyParameter(new Uint8List.view(seedToken.buffer, 0, 16)),
+          new Uint8List(16));
+      rnd.seed(rndParams);
+
+      ParametersWithRandom paramsWithRandom = new ParametersWithRandom(params,
+          rnd);
+      KeyGenerator gen = new KeyGenerator("RSA");
+      gen.init(paramsWithRandom);
+      AsymmetricKeyPair keys = gen.generateKeyPair();
+      return _prefs.setValue('adb_rsa_keys', _serializeRSAKeys(keys))
+          .then((_) => keys);
+    });
+  }
+
+  // Waits to receive either an ATUH or CNXN message. Handles AUTH as needed.
+  // Resolves when the handshake is done.
+  Future expectConnectionMessage() {
+    bool sentSignature = false;
+    bool sentPubKey = false;
+    AsymmetricKeyPair keys;
+    Future handleConnectionMessage() {
+      return receive().then((msg) {
+        if (msg.command == AdbUtil.A_AUTH) {
+          // We have been given a token.
+          // If we haven't tried the keys yet, try them.
+          if (!sentSignature) {
+            // Fetch the keys, supplying the random token from the device as the
+            // seed for the random number generator.
+            return getKeys(msg.dataBuffer)
+            .then((keys_) {
+              keys = keys_;
+
+              // First we create a SecureRandom, using the latter 16 bytes of
+              // the token as the seed. This is to keep it from being the same
+              // as the key generator seed, which would have been the first 16.
+              SecureRandom rnd = new SecureRandom('AES/CTR/PRNG');
+              ParametersWithIV rndParams = new ParametersWithIV(
+                  new KeyParameter(new Uint8List.view(
+                      msg.dataBuffer.buffer, 4, 16)),
+                  new Uint8List(16));
+              rnd.seed(rndParams);
+
+              // Next we prepare the Signer.
+              PrivateKeyParameter<RSAPrivateKey> pkParam =
+                  new PrivateKeyParameter<RSAPrivateKey>(keys.privateKey);
+              ParametersWithRandom params = new ParametersWithRandom(pkParam,
+                  rnd);
+              Signer signer = new Signer("SHA-1/RSA");
+              signer.init(true, params);
+
+              // And finally create the signature.
+              RSASignature sig = signer.generateSignature(
+                  new Uint8List.view(msg.dataBuffer.buffer));
+              // And send back the signed token.
+              AdbMessage response = new AdbMessage(AdbUtil.A_AUTH,
+                  AdbUtil.ADB_AUTH_SIGNATURE, 0);
+              response.setData(new ByteData.view(sig.bytes.buffer));
+              sentSignature = true;
+              return sendMessage(response).then((_) {
+                return handleConnectionMessage();
+              });
+            });
+          } else if (!sentPubKey) {
+            // If we have tried the keys, then send our public key.
+            // The public key consists of the following:
+            // - Length of key in words (64, for 2048-bit keys), 32-bit LE.
+            // - Inverse of the least-significant 32 bits of the modulus.
+            // - The modulus itself, little endian.
+            // - 2^4096 mod n, also little endian.
+            // - The exponent, same as is used in the key generation above.
+            //   (32-bit little endian).
+            // Which is all Base64-encoded and has a user@host username
+            // appended. That may be important, so I'll include one.
+
+            // Why this format? I have no idea. Especially the r^2 thing,
+            // which can be recomputed from the modulus.
+            ByteData data = new ByteData(4 + 4 + 256 + 256 + 4);
+            // First compute the little checksum that goes near the beginning.
+            // It's the multiplicative inverse of the first 32 bits of the
+            // modulus.
+            BigInteger modulus = keys.publicKey.modulus;
+            BigInteger twoTo32 = BigInteger.TWO.pow(32);
+            BigInteger firstWord = modulus.mod(twoTo32);
+            BigInteger negated = twoTo32 - firstWord;
+            BigInteger inverse = negated.modInverse(twoTo32);
+
+            // Write in the length, inverse, and the exponent.
+            data.setUint32(0, 64, Endianness.LITTLE_ENDIAN);
+            data.setUint32(4, inverse.intValue(), Endianness.LITTLE_ENDIAN);
+            data.setUint32(4+4+256+256, keys.publicKey.exponent.intValue(),
+                Endianness.LITTLE_ENDIAN);
+
+            // Write the modulus. It gets returned as a byte array, but it's
+            // big-endian. We want it little-endian, so we write it backwards.
+            List<int> beModulus = modulus.toByteArray();
+            int top = 256 + 4 + 4 - 1; // Index of the most-significant byte.
+            // HACK: For some reason, the BigInteger for the modulus is 257
+            // bytes long, with an extra 0 in its MSB. So we skip over it.
+            // Hopefully this applies to all keys, but it could be made more
+            // robust, always copying the least-significant 256 bytes from the
+            // array.
+            int extra = beModulus.length - 256;
+            for (int i = extra; i < beModulus.length; i++) {
+              data.setUint8(top - (i - extra), beModulus[i]);
+            }
+
+            // Now the weird part: computing what's called r^2.
+            // This is (2^2048)^2 % modulus.
+            BigInteger r2 = BigInteger.TWO.pow(4096).mod(modulus);
+            List<int> ber2 = r2.toByteArray();
+            top = 256 + 256 + 4 + 4 - 1; // Index of the most-significant byte.
+            extra = ber2.length - 256;
+            for (int i = extra; i < ber2.length; i++) {
+              data.setUint8(top - (i - extra), ber2[i]);
+            }
+
+            // Convert the binary data to a Base64 String.
+            String b64data = CryptoUtils.bytesToBase64(
+                new Uint8List.view(data.buffer).toList());
+
+            // Now the payload is ready, so we reply with the message.
+            AdbMessage response = new AdbMessage(AdbUtil.A_AUTH,
+                AdbUtil.ADB_AUTH_RSAPUBLICKEY, 0,
+                "$b64data spark@chrome\x00");
+            Uint8List temp = new Uint8List.view(response.dataBuffer.buffer);
+            sentPubKey = true;
+            return sendMessage(response).then((_) {
+              return handleConnectionMessage();
+            });
+          } else {
+            // We've tried signing, and tried sending our pubkey, and are
+            // still not authenticated? Something went wrong.
+            return new Future.error(
+                'Got AUTH TOKEN command even after RSAPUBKEY response.');
+          }
+        } else if (msg.command == AdbUtil.A_CNXN) {
+          // If we receive a CNXN in response, then we're authenticated!
+          // There's nothing to handle in this message, so we just return.
+          return null;
+        } else {
+          // Unexpected message type. Do nothing, and keep calling myself.
+          return handleConnectionMessage();
+        }
+      });
+    } // End of handleConnectionMessage.
+
+    // handleConnectionMessage will repeatedly call itself, eventually
+    // returning when it is successfully authenticated.
+    return handleConnectionMessage();
+  }
+
+  // Either resolves with an AdbMessage (including data portion, if applicable),
+  // or rejects with a chrome.TransferResultInfo giving the bad resultCode.
+  Future<AdbMessage> receive() {
+    AdbMessage readAdbMessage;
+    chrome.GenericTransferInfo readTransferInfo =
+        new chrome.GenericTransferInfo()
+        ..direction = inDescriptor.direction
+        ..endpoint = inDescriptor.address
+        ..length = AdbUtil.MESSAGE_SIZE_PAYLOAD;
+
+    return chrome.usb.bulkTransfer(adbConnectionHandle, readTransferInfo)
+        .then((chrome.TransferResultInfo readResult) {
+      // Read back a MessageBuffer for AUTH response.
+      if (readResult.resultCode != 0) {
+        return new Future.error(readResult);
+      }
+
+      readAdbMessage = new AdbMessage.fromMessageBufferBytes(
+          readResult.data.getBytes());
+
+      if (readAdbMessage.dataLength > 0) {
+        chrome.GenericTransferInfo readDataInfo =
+            new chrome.GenericTransferInfo()
+            ..direction = inDescriptor.direction
+            ..endpoint = inDescriptor.address
+            ..length = readAdbMessage.dataLength;
+
+        return chrome.usb.bulkTransfer(adbConnectionHandle, readDataInfo)
+            .then((chrome.TransferResultInfo readDataResult) {
+          if (readDataResult.resultCode != 0) {
+            return new Future.error(readDataResult);
+          }
+          // TODO(shepheb): This is slow, copying through List<int>.
+          // It would be much better to have a way to convert more directly.
+          readAdbMessage.loadDataBuffer(readDataResult.data.getBytes());
+          return readAdbMessage;
+        });
+      } else {
+        return readAdbMessage;
+      }
+    });
+  }
+
+  // Returns the ID of the remote end.
+  // This is only relevant for the OKAY after an OPEN, but harmless to return
+  // always.
+  Future<int> awaitOkay() {
+    return receive().then((msg) {
+      if (msg.command == AdbUtil.A_OKAY) {
+        return msg.arg0;
+      } else {
+        return new Future.error('Expected an OKAY but got: ${msg.toString()}');
+      }
+    });
+  }
+
+  // Expects the complete HTTP request as a List<int>, and the port as an int.
+  // Sends a single HTTP request, reads a single response. Returns the complete
+  // response, headers and all. In case of an error, rejects the Future with an
+  // error message.
+  // Technically this will work for sending any TCP request/response pair.
+  Future<List<int>> sendHttpRequest(List<int> httpRequest, int port) {
+    int localID = 4; // Arbitrary choice.
+    int remoteID;
+    Queue<ByteData> responseChunks;
+
+    // Send the open message.
+    return sendMessage(new AdbMessage(AdbUtil.A_OPEN, localID, 0,
+            'tcp:$port\x00'))
+        .then((_) { return awaitOkay(); })
+        .catchError((e) {
+          // If we caught an error here, we probably got a CLSE instead.
+          // This means the remote end isn't listening to our port.
+          return new Future.error('Connection on port $port refused.');
+        }).then((remoteID_) {
+          remoteID = remoteID_;
+
+          // Prepare and send the parts of the message.
+          int chunkCount = (httpRequest.length / AdbUtil.MAX_PAYLOAD).ceil();
+          Iterable<ByteData> chunks = new Iterable.generate(chunkCount, (i) {
+            int start = i * AdbUtil.MAX_PAYLOAD;
+            int end = (i+1) * AdbUtil.MAX_PAYLOAD;
+            end = end > httpRequest.length ? httpRequest.length : end;
+
+            ByteData chunk = new ByteData(end-start);
+            for (int j = start; j < end; j++) {
+              chunk.setUint8(j-start, httpRequest[j]);
+            }
+            return chunk;
+          });
+
+          return Future.forEach(chunks, (packet) {
+            // Prepare the message.
+            AdbMessage msg = new AdbMessage(AdbUtil.A_WRTE, localID, remoteID);
+            msg.setData(packet);
+            return sendMessage(msg).then((_) {
+              return awaitOkay();
+            });
+          });
+        }).then((_) {
+          // We've finished sending the request, now we await the response.
+          // Since we don't know when the response is all done, we simply await
+          // a 500ms pause after the last message.
+          // TODO(shepheb): Maybe make this HTTP-specific and understand the
+          // response and its Content-length?
+          responseChunks = new Queue<ByteData>();
+
+          Future readChunk() {
+            return receive().timeout(new Duration(milliseconds: 800))
+                .then((msg) {
+                  if (msg.command == AdbUtil.A_WRTE) {
+                    responseChunks.add(msg.dataBuffer);
+                    return sendMessage(new AdbMessage(AdbUtil.A_OKAY, localID,
+                        remoteID)).then((_) { return readChunk(); });
+                  } else {
+                    return new Future.error('Unexpected message from device.');
+                  }
+                }).catchError((e) {
+                  if (e is TimeoutException) {
+                    return null;
+                  } else {
+                    return new Future.error(e);
+                  }
+                });
+          };
+
+          return readChunk();
+        }).then((_) {
+          // Send a CLSE and expect a CLSE back.
+          return sendMessage(new AdbMessage(AdbUtil.A_CLSE, 0, remoteID));
+        }).then((_) {
+          // Turn responseChunks into a List<int> and return it.
+          List<int> ret = [];
+          for (ByteData chunk in responseChunks) {
+            for (int i = 0; i < chunk.lengthInBytes; i++) {
+              ret.add(chunk.getUint8(i));
+            }
+          }
+          return ret;
+        });
+  }
+
+  void handleMessage() {
+    // TODO(shepheb): Handle the incoming messages.
+  }
+}
+
+
+String _serializeRSAKeys(AsymmetricKeyPair keys) {
+  Map<String, String> cereal = new Map<String, String>();
+  cereal['p'] = keys.privateKey.p.toString(16);
+  cereal['q'] = keys.privateKey.q.toString(16);
+  cereal['modulus'] = keys.privateKey.modulus.toString(16);
+  cereal['privateexponent'] = keys.privateKey.exponent.toString(16);
+  cereal['publicexponent'] = keys.publicKey.exponent.toString(16);
+  return const JsonEncoder().convert(cereal);
+}
+
+AsymmetricKeyPair _deserializeRSAKeys(String json) {
+  Map<String, List<int>> cereal = const JsonDecoder(null).convert(json);
+  BigInteger p = new BigInteger(cereal['p'], 16);
+  BigInteger q = new BigInteger(cereal['q'], 16);
+  BigInteger modulus = new BigInteger(cereal['modulus'], 16);
+  BigInteger publicExponent = new BigInteger(cereal['publicexponent'], 16);
+  BigInteger privateExponent = new BigInteger(cereal['privateexponent'], 16);
+
+  RSAPublicKey public = new RSAPublicKey(modulus, publicExponent);
+  RSAPrivateKey private = new RSAPrivateKey(modulus, privateExponent, p, q);
+  return new AsymmetricKeyPair(public, private);
+}
+

--- a/ide/app/lib/harness_push.dart
+++ b/ide/app/lib/harness_push.dart
@@ -6,18 +6,64 @@ library spark.harness_push;
 
 import 'dart:async';
 
+import 'adb.dart';
 import 'jobs.dart';
+import 'preferences.dart';
 import 'tcp.dart';
 import 'workspace.dart';
 import 'workspace_utils.dart';
 
 class HarnessPush {
-  final Container appContainer;
+  // The single ADB connection is shared across all push contexts.
+  static AndroidDevice device;
 
-  HarnessPush(this.appContainer) {
+  final Container appContainer;
+  final PreferenceStore _prefs;
+
+  HarnessPush(this.appContainer, this._prefs) {
     if (appContainer == null) {
       throw new ArgumentError('must provide an app to push');
     }
+  }
+
+  List<int> _buildHttpRequest(String target, List<int> payload) {
+    List<int> httpRequest = [];
+    // Build the HTTP request headers.
+    String boundary = "--------------------------------a921a8f557cf";
+    String header = "POST /push?name=${appContainer.name}&type=crx HTTP/1.1\r\n"
+        + "User-Agent: Spark IDE\r\n"
+        + "Host: ${target}:2424\r\n"
+        + "Content-Type: multipart/form-data; boundary=$boundary\r\n";
+    List<int> body = [];
+    String bodyTop = "$boundary\r\n"
+        + "Content-Disposition: form-data; name=\"file\"; "
+        + "filename=\"SparkPush.crx\"\r\n"
+        + "Content-Type: application/octet-stream\r\n\r\n";
+    body.addAll(bodyTop.codeUnits);
+
+    // Add the CRX headers before the zip content.
+    // This is the string "Cr24" then three little-endian 32-bit numbers:
+    // - The version (2).
+    // - The public key length (0).
+    // - The signature length (0).
+    // Since the App Harness/Chrome ADT on the other end doesn't check
+    // the signature or key, we don't bother sending them.
+    body.addAll([67, 114, 50, 52, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+    // Now follows the actual zip data.
+    body.addAll(payload);
+
+    // Add the trailing boundary.
+    body.addAll([13, 10]); // \r\n
+    body.addAll(boundary.codeUnits);
+    // Two trailing hyphens to indicate the final boundary.
+    body.addAll([45, 45, 13, 10]); // --\r\n
+
+    httpRequest.addAll(header.codeUnits);
+    httpRequest.addAll("Content-length: ${body.length}\r\n\r\n".codeUnits);
+    httpRequest.addAll(body);
+
+    return httpRequest;
   }
 
   /**
@@ -44,44 +90,8 @@ class HarnessPush {
 
     return archiveContainer(appContainer).then((List<int> archivedData) {
       monitor.worked(3);
-      List<int> httpRequest = [];
-      // Build the HTTP request headers.
-      String boundary = "--------------------------------a921a8f557cf";
-      String header = "POST /push?name=${appContainer.name}&type=crx HTTP/1.1\r\n"
-          + "User-Agent: Spark IDE\r\n"
-          + "Host: ${target}:2424\r\n"
-          + "Content-Type: multipart/form-data; boundary=$boundary\r\n";
-      List<int> body = [];
-      String bodyTop = "$boundary\r\n"
-          + "Content-Disposition: form-data; name=\"file\"; "
-          + "filename=\"SparkPush.crx\"\r\n"
-          + "Content-Type: application/octet-stream\r\n\r\n";
-      body.addAll(bodyTop.codeUnits);
-
-      // Add the CRX headers before the zip content.
-      // This is the string "Cr24" then three little-endian 32-bit numbers:
-      // - The version (2).
-      // - The public key length (0).
-      // - The signature length (0).
-      // Since the App Harness/Chrome ADT on the other end doesn't check
-      // the signature or key, we don't bother sending them.
-      body.addAll([67, 114, 50, 52, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-
-      // Now follows the actual zip data.
-      body.addAll(archivedData);
-      monitor.worked(4);
-
-      // Add the trailing boundary.
-      body.addAll([13, 10]); // \r\n
-      body.addAll(boundary.codeUnits);
-      // Two trailing hyphens to indicate the final boundary.
-      body.addAll([45, 45, 13, 10]); // --\r\n
-
-      httpRequest.addAll(header.codeUnits);
-      httpRequest.addAll("Content-length: ${body.length}\r\n\r\n".codeUnits);
-      httpRequest.addAll(body);
-
-      monitor.worked(1);
+      List<int> httpRequest = _buildHttpRequest(target, archivedData);
+      monitor.worked(5);
 
       TcpClient client;
       return TcpClient.createClient(target, 2424).then((TcpClient _client) {
@@ -105,6 +115,80 @@ class HarnessPush {
           client.dispose();
         }
       });
+    });
+  }
+
+  // NB: All new devices added here must also be added to manifest.json, under
+  // usbDevices.
+  static final _KNOWN_DEVICES = [
+    { 'vendorId': 0x18d1, 'productId': 0x4ee1 }, // Nexus 4 (and 5?)
+    { 'vendorId': 0x18d1, 'productId': 0x4ee2 }, // Nexus 5 (and 4?)
+    { 'vendorId': 0x18d1, 'productId': 0x4ee6 }, // Nexus 10
+    { 'vendorId': 0x18d1, 'productId': 0x4e41 }, // Nexus 7 MTP
+    { 'vendorId': 0x18d1, 'productId': 0x4e43 }, // Nexus 7 PTP
+    { 'vendorId': 0x04e8, 'productId': 0x685e }, // Galaxy S II debug mode
+    { 'vendorId': 0x04e8, 'productId': 0x6866 }, // Galaxy S III debug mode
+    { 'vendorId': 0x0bb4, 'productId': 0x0f63 }  // HTC One
+  ];
+
+
+  // Safe to call multiple times. It will open the device if it has not been opened yet.
+  Future _fetchAndroidDevice() {
+    if (device == null) {
+      device = new AndroidDevice(_prefs);
+
+      Future doOpen(int index) {
+        if (index >= _KNOWN_DEVICES.length) {
+          device = null;
+          return new Future.error('No known devices connected');
+        }
+
+        Map m = _KNOWN_DEVICES[index];
+        return device.open(m['vendorId'], m['productId'])
+        .catchError((e) {
+          // If it failed to open, try again.
+          return doOpen(index+1);
+        });
+      }
+
+      return doOpen(0).then((_) {
+        return device.connect(new SystemIdentity());
+      }).then((_) => device);
+    } else {
+      return new Future.value(device);
+    }
+  }
+
+  Future pushADB(ProgressMonitor monitor) {
+    monitor.start('Deploying…', 10);
+    List<int> httpRequest;
+
+    return archiveContainer(appContainer).then((List<int> archivedData) {
+      monitor.worked(3);
+      httpRequest = _buildHttpRequest("localhost", archivedData);
+      monitor.worked(4);
+
+      // Now send this payload to the USB code.
+      return _fetchAndroidDevice();
+    }).then((device) {
+      return device.sendHttpRequest(httpRequest, 2424).timeout(
+          new Duration(seconds: 30), onTimeout: () {
+            return new Future.error('Push timed out');
+          });
+    }).then((msg) {
+      monitor.worked(3);
+      String resp = new String.fromCharCodes(msg);
+      List<String> lines = resp.split('\r\n');
+      Iterable<String> header = lines.takeWhile((l) => l.isNotEmpty);
+      String body = lines.skip(header.length + 1).join('<br>\n');
+
+      if (header.first.indexOf('200') < 0) {
+        // Error! Fail with the error line.
+        return new Future.error(
+            '${header.first.substring(header.first.indexOf(' ') + 1)}: $body');
+      } else {
+        return body;
+      }
     });
   }
 }

--- a/ide/app/manifest.json
+++ b/ide/app/manifest.json
@@ -43,7 +43,44 @@
     "storage",
     "unlimitedStorage",
     "webview",
-    "contextMenus"
+    "contextMenus",
+    "usb",
+    {
+      "usbDevices": [
+        {
+          "vendorId": 6353,
+          "productId": 20193
+        },
+        {
+          "vendorId": 6353,
+          "productId": 20194
+        },
+        {
+          "vendorId": 6353,
+          "productId": 20198
+        },
+        {
+          "vendorId": 6353,
+          "productId": 20033
+        },
+        {
+          "vendorId": 6353,
+          "productId": 20035
+        },
+        {
+          "vendorId": 1256,
+          "productId": 26718
+        },
+        {
+          "vendorId": 1256,
+          "productId": 26726
+        },
+        {
+          "vendorId": 2996,
+          "productId": 3939
+        }
+      ]
+    }
   ],
   "sockets": {
     "tcp": {

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -233,8 +233,17 @@
       </div>
       <div class="modal-body">
         <div class="form-group">
-          <label for="pushUrl">Target Host</label>
-          <input id="pushUrl" type="text" class="form-control" placeholder="e.g. 192.168.1.101" />
+          <div>
+            <input type="radio" name="type" value="push-adb" id="adb" checked />
+            <label for="adb" checked>ADB over USB</label>
+          </div>
+          <div>
+            <input type="radio" name="type" value="push-ip" id="ip" />
+            <label for="ip">Directly over network</label>
+
+            <label for="pushUrl">Target Host</label>
+            <input id="pushUrl" type="text" class="form-control" placeholder="e.g. 192.168.1.101" />
+          </div>
         </div>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
@devoncarew for review.

This allows deployment to a connected Android device.
Due to limitations in the chrome.usb API, we must whitelist device
models, rather than searching for any Android device.

The following devices are currently whitelisted:
- Nexus 4, 5, 7, 7v2, and 10.
- Galaxy S 2 and 3.
- HTC One
  More devices can be easily added: find their vendor ID and product ID
  with lsusb, and put them into the manifest.json usbDevices list, and in
  the _KNOWN_DEVICES list in lib/harness_push.dart.

Known Issues:
- Something is wrong with the authentication: the device does not
  remember the host, and the user must press OK to the Android debug
  dialog every time the connection must be re-established.
- Switching devices without restarting Spark currently does not work.
