### PR TITLE
roll back ace

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -156,7 +156,7 @@ class AceManager {
     _aceEditor.highlightActiveLine = false;
     _aceEditor.printMarginColumn = 80;
     _aceEditor.readOnly = true;
-    _aceEditor.fadeFoldWidgets = true;
+    //_aceEditor.fadeFoldWidgets = true;
 
     // Enable code completion.
     ace.require('ace/ext/language_tools');
@@ -281,10 +281,10 @@ class AceManager {
 
   void _selectMarker(workspace.Marker marker) {
     _aceEditor.gotoLine(marker.lineNum);
-    ace.Selection selection = _aceEditor.selection;
-    ace.Range range = selection.getLineRange(marker.lineNum - 1);
-    selection.setSelectionAnchor(range.end.row, range.end.column);
-    selection.selectTo(range.start.row, range.start.column);
+//    ace.Selection selection = _aceEditor.selection;
+//    ace.Range range = selection.getLineRange(marker.lineNum - 1);
+//    selection.setSelectionAnchor(range.end.row, range.end.column);
+//    selection.selectTo(range.start.row, range.start.column);
     _aceEditor.focus();
     _currentMarker = marker;
   }

--- a/ide/app/lib/adb.dart
+++ b/ide/app/lib/adb.dart
@@ -207,8 +207,10 @@ class AndroidDevice {
     CipherBase.initCipher();
   }
 
+  // TODO: add generic type info to the Future
   Future listDevices() {
     // TODO (shepheb): List all Android devices.
+    return new Future.value([]);
   }
 
   // Either resolves on successful open, or rejects with an error message on failure.

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/GoogleChrome/spark
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
-  ace: '>=0.3.4 <0.4.0'
+  ace: 0.3.3+1.8.2014
   analyzer: '>=0.11.0 <0.12.0'
   archive: '>=1.0.15 <1.1.0'
   benchmark_harness: '>=1.0.4 <2.0.0'


### PR DESCRIPTION
Temporarily roll ace back to `0.3.3` because of a regression in paste; ctrl-v throws as exception.
