### PR TITLE
Improve usability of cannot-launch alert.

### DIFF
--- a/ide/app/cannot_launch/cannot_launch.css
+++ b/ide/app/cannot_launch/cannot_launch.css
@@ -13,6 +13,12 @@ body {
 
 h1 {
   font-size: 20px;
+
+}
+
+.selectable-link {
+  -webkit-user-select: text;
+  font-family: "courier new";
 }
 
 #message {

--- a/ide/app/cannot_launch/cannot_launch.htm
+++ b/ide/app/cannot_launch/cannot_launch.htm
@@ -19,8 +19,8 @@
     <div>
       <h1>Cannot launch</h1>
       <div id="message">
-      Please check whether 'Enable experimental Web Platform features' is enabled
-      in chrome://flags.
+      Please enable the <strong>experimental Web Platform features</strong> flag
+      in <span class="selectable-link">chrome://flags/#enable-experimental-web-platform-features</span> and then restart Chrome.
       </div>
       <div id="footer">
         <button id="close-button">Close</button>


### PR DESCRIPTION
The previous language didn't indicate which way the flag should be
set, but merely said to "check" it. The new language is more
precise. The alert now presents a link that can be manually copied
and pasted into an address bar, taking the user directly to the
relevant flag.
