### PR TITLE
fix nits from recent polymer roll

### DIFF
--- a/ide/app/lib/services/services_impl.dart
+++ b/ide/app/lib/services/services_impl.dart
@@ -284,7 +284,7 @@ class AnalyzerServiceImpl extends ServiceImpl {
   }
 
   OutlineEntry populateOutlineEntry(
-      OutlineEntry outlineEntry, analyzer.ASTNode node) {
+      OutlineEntry outlineEntry, analyzer.AstNode node) {
     outlineEntry.startOffset = node.beginToken.offset;
     outlineEntry.endOffset = node.endToken.end;
     return outlineEntry;

--- a/ide/app/lib/ui/polymer/commit_message_view/commit_message_view.html
+++ b/ide/app/lib/ui/polymer/commit_message_view/commit_message_view.html
@@ -9,7 +9,7 @@
     <!-- BUG: https://code.google.com/p/dart/issues/detail?id=14382 -->
     <!-- link rel="stylesheet" href="xyz.css" -->
     <style>
-      @import url("lib/ui/polymer/commit_message_view/commit_message_view.css");
+      @import url("commit_message_view.css");
     </style>
 
     <div id="message">{{commitInfo.message}}</div>


### PR DESCRIPTION
Fixed two nits from the recent polymer roll (https://github.com/dart-lang/spark/pull/1272):
- an analyzer class was renamed for the `analyzer-0.13.0-dev.5` version
- fix a missing css error message from running Spark in Dartium. I've verified that the new css reference works for both Dartium and the deployed dart2js version.

@ussuri
