### PR TITLE
More robust error recovery and better error messages for ADB

### DIFF
--- a/ide/app/lib/adb.dart
+++ b/ide/app/lib/adb.dart
@@ -337,7 +337,10 @@ class AndroidDevice {
   // Connects to and authenticates with the device.
   Future connect(SystemIdentity systemIdentity) {
     return chrome.usb.claimInterface(adbConnectionHandle,
-        adbInterface.interfaceNumber).then((_) {
+        adbInterface.interfaceNumber).catchError((_) {
+      return new Future.error(
+        'Could not open ADB connection. Do you already have ADB running?');
+    }).then((_) {
       AdbMessage adbMessage = new AdbMessage(AdbUtil.A_CNXN, AdbUtil.A_VERSION,
           AdbUtil.MAX_PAYLOAD, systemIdentity.toString());
 
@@ -584,12 +587,13 @@ class AndroidDevice {
     // Send the open message.
     return sendMessage(new AdbMessage(AdbUtil.A_OPEN, localID, 0,
             'tcp:$port\x00'))
-        .then((_) { return awaitOkay(); })
         .catchError((e) {
           // If we caught an error here, we probably got a CLSE instead.
           // This means the remote end isn't listening to our port.
+          print(e);
           return new Future.error('Connection on port $port refused.');
-        }).then((remoteID_) {
+        }).then((_) { return awaitOkay(); })
+        .then((remoteID_) {
           remoteID = remoteID_;
 
           // Prepare and send the parts of the message.

--- a/ide/app/lib/harness_push.dart
+++ b/ide/app/lib/harness_push.dart
@@ -154,7 +154,10 @@ class HarnessPush {
 
       return doOpen(0).then((_) {
         return device.connect(new SystemIdentity());
-      }).then((_) => device);
+      }).then((_) => device).catchError((e) {
+        device = null;
+        return new Future.error(e);
+      });
     } else {
       return new Future.value(device);
     }


### PR DESCRIPTION
Failure to claim the interface due to ADB already running is a common
failure, the error message now suggests this cause.

Also, a failure of that kind would leave the AndroidDevice object
around, but it had failed to connect. Future attempts to push would
result in the bad error message "Connection refused on port 2424", when
really there was no USB interface to send the message on. Now when the
connection fails, the AndroidDevice object is nulled, and future Deploy
attempts will start fresh.

@devoncarew to review.
