### PR TITLE
increase test driver timeout

### DIFF
--- a/ide/tool/test_runner.dart
+++ b/ide/tool/test_runner.dart
@@ -26,7 +26,7 @@ Process chromeProcess;
 int exitCode;
 Directory tempDir;
 
-final int TEST_TIMEOUT = 30;
+final int TEST_TIMEOUT = 45;
 final int CHROME_SHUTDOWN_TIMEOUT = 1;
 final int EXIT_PROCESS_TIMEOUT = 1;
 


### PR DESCRIPTION
@dinhviethoa - increaese our test driver timeout, now that the test timeout has increased to 30 seconds. This prevents the test driver from killing chrome when the tests are still running.
