### PR TITLE
Fix spark-selector: a click on the details of an item wouldn't open it

### DIFF
--- a/widgets/lib/spark_selector/spark_selector.dart
+++ b/widgets/lib/spark_selector/spark_selector.dart
@@ -193,8 +193,8 @@ class SparkSelector extends SparkWidget {
   }
 
   // Event fired from host.
-  void clickHandler(Event e) {
-    if (e.target == _active) {
+  void clickHandler(MouseEvent e) {
+    if (_active.contains(e.target)) {
       _commitActiveToSelected();
     } else {
       // This will happen if the user clicks on some element not designated as


### PR DESCRIPTION
@dinhviethoa
