### PR TITLE
add default focused button to publish webstore dialog

### DIFF
--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -561,7 +561,7 @@
         <spark-button overlay-toggle data-dismiss="modal">
           Cancel
         </spark-button>
-        <spark-button overlay-toggle primary data-dismiss="modal">
+        <spark-button overlay-toggle primary focused data-dismiss="modal">
           Publish
         </spark-button>
       </div>


### PR DESCRIPTION
Fixes https://github.com/dart-lang/spark/issues/1309
the reason is there's no default focused button.

TBR
