### PR TITLE
Fixed suggest-box items unclickable on Windows/Linux (bug #1320)

### DIFF
--- a/widgets/lib/spark_suggest_box/spark_suggest_box.css
+++ b/widgets/lib/spark_suggest_box/spark_suggest_box.css
@@ -20,6 +20,10 @@
   max-height: 350px;
   overflow-y: scroll;
   overflow-x: hidden;
+
+  /* BUG: #1320. Do not remove! */
+  -webkit-transform: scaleZ(1);
+  transform: scaleZ(1);
 }
 
 #suggestion-list-menu {


### PR DESCRIPTION
@dinhviethoa

Fixes #1321.
#1320 is the corresponding TODO that describes the results of the investigation.
