### PR TITLE
Change suggest-box results overlay animation from 'scale-slideup' to 'fade'

### DIFF
--- a/widgets/lib/spark_suggest_box/spark_suggest_box.html
+++ b/widgets/lib/spark_suggest_box/spark_suggest_box.html
@@ -48,7 +48,7 @@
 
     <spark-overlay id="suggestion-list-overlay"
         autoClose
-        animation="scale-slideup"
+        animation="fade"
         opened="{{opened}}"
         on-opened="{{overlayOpenedHandler}}">
 


### PR DESCRIPTION
Fixes #1298

@lukechurch
