### PR TITLE
upgrade to the dev.8 release of the analyzer

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
   ace: '>=0.3.5 <0.4.0'
-  analyzer: 0.13.0-dev.5
+  analyzer: 0.13.0-dev.8
   archive: '>=1.0.16 <1.1.0'
   benchmark_harness: '>=1.0.4 <2.0.0'
   bignum: '>=0.0.5 <0.1.0'
@@ -35,7 +35,7 @@ dev_dependencies:
   args: any
   grinder: '>=0.5.0 <0.6.0'
 dependency_overrides:
-  analyzer: 0.13.0-dev.5
+  analyzer: 0.13.0-dev.8
 transformers:
 - polymer:
     entry_points: web/spark_polymer.html


### PR DESCRIPTION
TBR, upgrade to the 0.13.0-dev.8 release of the analyzer, to capture a workaround for a dart2js bug (https://code.google.com/p/dart/issues/detail?id=17483)

@bwilkerson, @scheglov, @jwren
