### PR TITLE
add some more info to the deploy dialog

### DIFF
--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -66,7 +66,7 @@ class SparkPolymerDialog implements SparkDialog {
 class SparkPolymer extends Spark {
   SparkPolymerUI _ui;
 
-  Future<bool> openFolder() {
+  Future openFolder() {
     return _beforeSystemModal()
         .then((_) => super.openFolder())
         .then((_) => _systemModalComplete())
@@ -230,16 +230,10 @@ class SparkPolymer extends Spark {
     }
   }
 
-  Future<bool> _beforeSystemModal() {
-    Completer completer = new Completer();
+  Future _beforeSystemModal() {
     backdropShowing = true;
 
-    Timer timer =
-        new Timer(new Duration(milliseconds: 100), () {
-          completer.complete();
-        });
-
-    return completer.future;
+    return new Future.delayed(new Duration(milliseconds: 100));
   }
 
   void _systemModalComplete() {

--- a/ide/app/spark_polymer_ui.dart
+++ b/ide/app/spark_polymer_ui.dart
@@ -70,21 +70,25 @@ class SparkPolymerUI extends SparkWidget {
   }
 
   void bindKeybindingDesc() {
-    final items = getShadowDomElement('#mainMenu').querySelectorAll('spark-menu-item');
+    final items = getShadowDomElement('#mainMenu').querySelectorAll(
+        'spark-menu-item');
     items.forEach((menuItem) {
       final actionId = menuItem.attributes['action-id'];
       final action = SparkModel.instance.actionManager.getAction(actionId);
-      action.bindings.forEach((keyBind) => menuItem.description = keyBind.getDescription());
+      action.bindings.forEach(
+          (keyBind) => menuItem.description = keyBind.getDescription());
     });
   }
 
   void onResetGit() {
-    SparkModel.instance.syncPrefs.removeValue(['git-auth-info', 'git-user-info']);
+    SparkModel.instance.syncPrefs.removeValue(
+        ['git-auth-info', 'git-user-info']);
     SparkModel.instance.setGitSettingsResetDoneVisible(true);
   }
 
   void onResetPreference() {
-    Element resultElement = getShadowDomElement('#preferenceResetResult')..text = '';
+    Element resultElement = getShadowDomElement('#preferenceResetResult');
+    resultElement.text = '';
     SparkModel.instance.syncPrefs.clear().then((_) {
       SparkModel.instance.localPrefs.clear();
     }).catchError((e) {
@@ -92,5 +96,11 @@ class SparkPolymerUI extends SparkWidget {
     }).then((_) {
       resultElement.text = 'Preferences are reset. Restart Spark.';
     });
+  }
+
+  void handleAnchorClick(Event e) {
+    e..preventDefault()..stopPropagation();
+    AnchorElement anchor = e.target;
+    window.open(anchor.href, '_blank');
   }
 }

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -234,17 +234,24 @@
         <h4 class="modal-title">Deploy to Mobile</h4>
       </div>
       <div class="modal-body">
+        <h4>Deploy a Chrome App to an Android Device</h4>
+        <p>
+          You need to have the
+          <a href="https://github.com/MobileChromeApps/harness/releases/"
+              on-click="{{handleAnchorClick}}">
+            ChromeAPT.apk
+          </a>
+          installed on your Android phone or tablet.
+        </p>
         <div class="form-group">
           <form>
             <div>
-              <input type="radio" name="type" value="push-adb" id="adb" checked />
-              <label for="adb">ADB over USB</label>
+              <input id="adb" type="radio" name="type" value="push-adb" checked />
+              <label for="adb">Deploy via USB</label>
             </div>
             <div>
-              <label for="ip">Directly over network</label>
               <input id="ip" type="radio" name="type" value="push-ip" />
-
-              <label for="pushUrl">Target Host</label>
+              <label for="ip">Deploy to a network host</label>
               <input id="pushUrl" type="text" class="form-control"
                   placeholder="e.g. 192.168.1.101" />
             </div>
@@ -255,7 +262,7 @@
         <spark-button overlay-toggle data-dismiss="modal">
           Cancel
         </spark-button>
-        <spark-button overlay-toggle primary data-dismiss="modal">
+        <spark-button overlay-toggle primary focused data-dismiss="modal">
           Deploy
         </spark-button>
       </div>


### PR DESCRIPTION
UX changes to the deploy dialog:
- have an initial focused item, so that escape will close the dialog
- fix a css issue with the radio buttons
- add some helper text to tell the user how to get the ChromeAPT APK
- (misc style nits in `park_polymer.dart`)

Before:
![screen shot 2014-03-16 at 9 50 09 am](https://f.cloud.github.com/assets/1269969/2431466/399725b0-ad30-11e3-9a53-88cfae61ad0d.png)

After:
![screen shot 2014-03-16 at 9 48 28 am](https://f.cloud.github.com/assets/1269969/2431468/44ede598-ad30-11e3-83f5-83b6229ee598.png)

@shepheb
