### PR TITLE
expand min-height-window size

### DIFF
--- a/ide/app/background.js
+++ b/ide/app/background.js
@@ -72,7 +72,7 @@ var EditorWindow = function(app) {
         height: Math.floor(screen.availHeight * (7/8))
       },
       minWidth: 900,
-      minHeight: 450,
+      minHeight: 550,
     },
     this.onCreated_.bind(this)
   );


### PR DESCRIPTION
to make minHeight covers the dialogs.
@devoncarew

Before
![image](https://f.cloud.github.com/assets/756988/2438955/1c96e270-adf8-11e3-812e-9705d82c92a1.png)

After
![image](https://f.cloud.github.com/assets/756988/2438958/213df53e-adf8-11e3-93ea-d265c654a449.png)
