### PR TITLE
context position tweak

### DIFF
--- a/ide/app/lib/ui/files_controller.dart
+++ b/ide/app/lib/ui/files_controller.dart
@@ -733,7 +733,7 @@ class FilesController implements TreeViewDelegate {
     if (estimatedHeight + clickPoint.y > topUi.offsetHeight) {
       var positionY = clickPoint.y - estimatedHeight;
       if (positionY < 0) {
-        // Add additional 5px to show 'shadow' of context menu.
+        // Add additional 5px to show boundary of context menu.
         contextMenu.style.top = '${topUi.offsetHeight - estimatedHeight - 5}px';
       } else {
         contextMenu.style.top = '${positionY}px';


### PR DESCRIPTION
@dinhviethoa please review. 
- if context menu cropped, move context to above of clicked point.
- if upper side & down side  of context menu is cropped, align to bottom.

Sorry about my poor english description.

After
![image](https://f.cloud.github.com/assets/756988/2444688/e56c15d4-ae5d-11e3-8def-a877750befa1.png)

add additional 5px to show boundary.
![image](https://f.cloud.github.com/assets/756988/2444695/1cd19684-ae5e-11e3-9df5-a009f34e2647.png)
