### PR TITLE
Fix exception in spark-selector when firing an 'activate' event

### DIFF
--- a/widgets/lib/spark_selector/spark_selector.dart
+++ b/widgets/lib/spark_selector/spark_selector.dart
@@ -176,8 +176,6 @@ class SparkSelector extends SparkWidget {
     if (item != null) {
       _renderSelected(item, detail['isSelected']);
 
-      detail['item'] = item;
-
       if (_fireEvents) {
         asyncFire('activate', detail: detail, canBubble: true);
       }


### PR DESCRIPTION
Polymer couldn't serialize the entire activated item in all cases, in particular when the item was a Polymer element itself (e.g. spark-menu-item).

TBR
