### PR TITLE
Revert "More precise complex :host selectors" - not needed anymore

### DIFF
--- a/widgets/lib/common/spark_widget.css
+++ b/widgets/lib/common/spark_widget.css
@@ -5,10 +5,10 @@
 @import url("../../../packages/bootjack/css/bootstrap.css");
 @import url("../../../packages/bootjack/css/bootstrap-theme.css");
 
-:host(.veiled:host) {
+:host(.veiled) {
   opacity: 0;
 }
 
-:host(.unveiled:host) {
+:host(.unveiled) {
   opacity: 1;
 }

--- a/widgets/lib/spark_icon_button/spark_icon_button.css
+++ b/widgets/lib/spark_icon_button/spark_icon_button.css
@@ -27,11 +27,11 @@
   background-position: 0 -44px;
 }
 
-:host(.selected:host) {
+:host(.selected) {
   background-position: 0 -88px;
 }
 
-:host:active, :host(.selected:host):active {
+:host:active, :host(.selected):active {
   background-position: 0 -132px;
 }
 

--- a/widgets/lib/spark_overlay/spark_overlay.css
+++ b/widgets/lib/spark_overlay/spark_overlay.css
@@ -50,18 +50,18 @@ We address this by using script based positioning =(
   It is then made visibility: visible when it is opened.
 */
 
-:host(.revealed:host) {
+:host(.revealed) {
   display: block;
   visibility: hidden;
 }
 
-:host(.revealed.opened:host) {
+:host(.revealed.opened) {
   opacity: 1;
   display: block;
   visibility: visible;
 }
 
-:host(.revealed.closing:host) {
+:host(.revealed.closing) {
   display: block;
   visibility: visible;
 }
@@ -74,28 +74,28 @@ We address this by using script based positioning =(
   NOTE: if a rule such as a media query changes an overlay from using a css
   animation to a transition, the animation class must be altered or removed.
 */
-:host(.animation-in-progress:host) {
+:host(.animation-in-progress) {
   -webkit-transition: none;
   transition: none;
 }
 
-:host([animation=fade]:host) {
+:host([animation=fade]) {
   opacity: 0;
   -webkit-transition: all 0.218s;
   transition: all 0.218s;
 }
 
-:host([animation=fade].opened:host) {
+:host([animation=fade].opened) {
   opacity: 1;
 }
 
-:host([animation=scale-slideup]:host) {
+:host([animation=scale-slideup]) {
   opacity: 0.0;
   -webkit-transform: scale(1.05);
   transform: scale(1.05);
 }
 
-:host([animation=scale-slideup].opened:host) {
+:host([animation=scale-slideup].opened) {
   opacity: 1.0;
   -webkit-transform: scale(1.0);
   transform: scale(1.0);
@@ -103,7 +103,7 @@ We address this by using script based positioning =(
   transition: all 0.218s;
 }
 
-:host([animation=scale-slideup].closing:host) {
+:host([animation=scale-slideup].closing) {
   opacity: 0;
   -webkit-transform: translateY(-100%);
   transform: translateY(-100%);
@@ -111,7 +111,7 @@ We address this by using script based positioning =(
   transition: all 0.4s;
 }
 
-:host([animation=shake].opened:host) {
+:host([animation=shake].opened) {
   -webkit-animation-duration: 0.5s;
   -webkit-animation-fill-mode: both;
   -webkit-animation-name: shake-fade-in;
@@ -120,7 +120,7 @@ We address this by using script based positioning =(
   animation-name: shake-fade-in;
 }
 
-:host([animation=shake].closing:host) {
+:host([animation=shake].closing) {
   -webkit-animation-duration: 0.5s;
   -webkit-animation-fill-mode: both;
   -webkit-animation-name: shake-fade-out;

--- a/widgets/lib/spark_split_view/spark_split_view.css
+++ b/widgets/lib/spark_split_view/spark_split_view.css
@@ -8,11 +8,11 @@
   display: flex;
 }
 
-:host([direction="left"]:host), :host([direction="right"]:host) {
+:host([direction="left"]), :host([direction="right"]) {
   flex-flow: row;
 }
 
-:host([direction="up"]:host), :host([direction="down"]:host) {
+:host([direction="up"]), :host([direction="down"]) {
   flex-flow: column;
 }
 
@@ -23,21 +23,21 @@
 /* If the resizing target is to the left or up, make the other one flex so
    it auto-adjusts.
 */
-:host([direction="left"]:host) > content[select=":nth-child(2)"]::content > * {
+:host([direction="left"]) > content[select=":nth-child(2)"]::content > * {
   flex: 1;
 }
 
-:host([direction="up"]:host) > content[select=":nth-child(2)"]::content > * {
+:host([direction="up"]) > content[select=":nth-child(2)"]::content > * {
   flex: 1;
 }
 
 /* If the resizing target is to the right or down, make the other one flex so
    it auto-adjusts.
 */
-:host([direction="right"]:host) > content[select=":nth-child(1)"]::content > * {
+:host([direction="right"]) > content[select=":nth-child(1)"]::content > * {
   flex: 1;
 }
 
-:host([direction="down"]:host) > content[select=":nth-child(1)"]::content > * {
+:host([direction="down"]) > content[select=":nth-child(1)"]::content > * {
   flex: 1;
 }

--- a/widgets/lib/spark_splitter/spark_splitter.css
+++ b/widgets/lib/spark_splitter/spark_splitter.css
@@ -12,17 +12,17 @@
   background-color: #F7F7F7;
 }
 
-:host(.horizontal:host) {
+:host(.horizontal) {
   cursor: row-resize;
 }
 
-:host(.vertical-handle:host) {
+:host(.vertical-handle) {
   background: url('handle_vert.png') no-repeat center;
 }
 
-:host(.horizontal-handle:host) {
+:host(.horizontal-handle) {
   background: url('handle_horiz.png') no-repeat center;
 }
 
-:host:hover, :host(.active:host) {
+:host:hover, :host(.active) {
 }

--- a/widgets/lib/spark_toggle_button/spark_toggle_button.css
+++ b/widgets/lib/spark_toggle_button/spark_toggle_button.css
@@ -20,7 +20,7 @@
   cursor: pointer;
 }
 
-:host(.on:host) {
+:host(.on) {
   border: 1px solid #4584f2;
 }
 


### PR DESCRIPTION
With the recent updates to the shadow DOM-related CSS rules, :host(X) will only match if X is on the :host itself, so :host(X:host) becomes unnecessary (before, :host(X) would match if the :host or any of its ancestors had X).

TBR
