### PR TITLE
add handling for the left key

### DIFF
--- a/ide/app/lib/ui/widgets/listview.dart
+++ b/ide/app/lib/ui/widgets/listview.dart
@@ -289,12 +289,10 @@ class ListView {
     });
     _addCurrentSelectionHighlight();
 
-    // If no selected row is set, we set one by default.
-    // It will help multi-selection using Shift key working as expected.
-    if (_selectedRow == -1) {
-      if (selection.length > 0) {
-        _selectedRow = selection.first;
-      }
+    if (selection.length > 0) {
+      _selectedRow = selection.first;
+    } else {
+      _selectedRow = -1;
     }
   }
 

--- a/ide/app/lib/ui/widgets/treeview.dart
+++ b/ide/app/lib/ui/widgets/treeview.dart
@@ -323,10 +323,12 @@ class TreeView implements ListViewDelegate {
           setNodeExpanded(uuid, false, animated: true);
         } else {
           // Select the parent.
-          // TODO: how to we get the parent uuid given the child uuid?
-          String parentUuid = uuid;
-          selection = [parentUuid];
-          scrollIntoNode(parentUuid);
+          String parentUuid = getParentUuid(uuid);
+          if (parentUuid != null) {
+            int index = _rows.indexOf(_rowsMap[parentUuid]);
+            _listView.selection = [index];
+            scrollIntoNode(parentUuid);
+          }
         }
 
         cancelEvent(event);
@@ -472,6 +474,20 @@ class TreeView implements ListViewDelegate {
   }
 
   bool get dropEnabled => _listView.dropEnabled;
+
+  String getParentUuid(String childUuid) {
+    int childIndex = _rows.indexOf(_rowsMap[childUuid]);
+    int childLevel = _rows[childIndex].level;
+
+    while (childIndex > -1) {
+      if (_rows[childIndex].level < childLevel) {
+        return _rows[childIndex].nodeUID;
+      }
+      childIndex--;
+    }
+
+    return null;
+  }
 
   /**
    *  Make sure the given node is selected.


### PR DESCRIPTION
Change the left cursor key handling in the files view. Specifically, a left arrow on a container that is expanded will collapse that container. A left arrow on anything else will select the parent of that element.

@dinhviethoa for review. Hoa, I have one question in the CL - given a uuid for a child node in the files view, how to I get the uuid for its parent?
