### PR TITLE
Fix annotation icons to override ace's

### DIFF
--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -61,15 +61,15 @@ body {
   color: #aaa;
 }
 
-.ace_gutter-cell.ace_error {
+div.ace_gutter-cell.ace_error {
   background-image: url("images/error_icon.png");
 }
 
-.ace_gutter-cell.ace_warning {
+div.ace_gutter-cell.ace_warning {
   background-image: url("images/warning_icon.png");
 }
 
-.ace_gutter-cell.ace_info {
+div.ace_gutter-cell.ace_info {
   background-image: url("images/info_icon.png");
 }
 


### PR DESCRIPTION
Made annotation selectors more specific (div.) in order to override ace's annotations.

![image](https://cloud.githubusercontent.com/assets/357955/2596730/b5b40d70-baaa-11e3-98cc-1cf05fd68c77.png)

Fixes #952
Review @ussuri 
