### PR TITLE
Improve timeouts for ADB push. Fixes #1319.

### DIFF
--- a/ide/app/lib/mobile/adb.dart
+++ b/ide/app/lib/mobile/adb.dart
@@ -639,6 +639,9 @@ Additionally, DevTools may not have released the USB connection. To check this g
             msg.setData(packet);
             return sendMessage(msg).then((_) {
               return awaitOkay();
+            }).timeout(new Duration(seconds: 10), onTimeout: () {
+              return new Future.error(
+                  'Push timed out: Single message took more than 10 seconds.');
             });
           });
         }).then((_) {

--- a/ide/app/lib/mobile/deploy.dart
+++ b/ide/app/lib/mobile/deploy.dart
@@ -194,8 +194,9 @@ class HarnessPush {
       _device = deviceResult;
 
       return _device.sendHttpRequest(httpRequest, 2424).timeout(
-          new Duration(seconds: 30), onTimeout: () {
-            return new Future.error('Push timed out');
+          new Duration(minutes: 5), onTimeout: () {
+            return new Future.error(
+                'Push timed out: Total time exceeds 5 minutes');
           });
     }).then((msg) {
       monitor.worked(3);


### PR DESCRIPTION
It was timing out while the request was still in progress, on larger
transfers and slower devices. Now there is a 10-seconds-between-packets
timeout and a master 5 minute timeout for the whole HTTP transaction. No
timeout on the RSA key generation or signing, though, since the crypto
is so slow.
