### PR TITLE
Add SparkError class to handle error and exceptions.

### DIFF
--- a/ide/app/lib/spark_exception.dart
+++ b/ide/app/lib/spark_exception.dart
@@ -6,7 +6,7 @@ library spark.exception;
 
 /**
  * A wrapper class for all errors thrown inside spark. Each error is represented
- * by a unique [errorCode] pre-defined in spark_error_constants.dart.
+ * by a unique [errorCode] pre-defined by SparkErrorConstants class.
  */
 class SparkException implements Exception {
   /// Represents the unique string for each error type.


### PR DESCRIPTION
Add an SparkError class which will enclose all errors thrown inside spark. Each error will be represented by a unique errorcode which will be a string. 

Naming convention of errorcode string ? (Ideas)
( Currently I added a prefix SPARK_ERR + library).

@dinhviethoa @devoncarew 
