### PR TITLE
Fix a typo that broke Pub support (and tests)

### DIFF
--- a/ide/app/lib/package_mgmt/pub.dart
+++ b/ide/app/lib/package_mgmt/pub.dart
@@ -26,7 +26,7 @@ class PubProperties extends PackageServiceProperties {
   String get packageSpecFileName => 'pubspec.yaml';
   String get packagesDirName => 'packages';
   String get libDirName => 'lib';
-  String get packageRefPrefix => 'prefix:';
+  String get packageRefPrefix => 'package:';
   RegExp get packageRefPrefixRegexp => new RegExp('^(package:|/packages/)(.*)');
 
   void setSelfReference(Project project, String selfReference) =>


### PR DESCRIPTION
The typo was introduced in a last minute commit for #1514 while addressing review comments.

TBR
