### PR TITLE
upgrade some packages to the latest versions

### DIFF
--- a/ide/app/lib/services.dart
+++ b/ide/app/lib/services.dart
@@ -10,7 +10,6 @@ import 'dart:isolate';
 import 'package:logging/logging.dart';
 
 import 'package_mgmt/package_manager.dart';
-import 'package_mgmt/pub.dart';
 import 'services/compiler.dart';
 import 'services/services_common.dart';
 import 'utils.dart';

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -11,12 +11,11 @@ dependencies:
   archive: '>=1.0.16 <1.1.0'
   benchmark_harness: '>=1.0.4 <2.0.0'
   bignum: '>=0.0.5 <0.1.0'
-  bootjack: any
+  bootjack: '>=0.6.0 < 0.7.0'
   chrome: '>=0.5.3 <0.6.0'
   cipher: '>=0.6.0 <0.7.0'
   compiler_unsupported: 0.7.1
   crypto: any
-  dquery: '>=0.5.0 <0.6.0'
   intl: any
   json: any
   logging: any
@@ -34,8 +33,6 @@ dependencies:
 dev_dependencies:
   args: any
   grinder: '>=0.5.0 <0.6.0'
-dependency_overrides:
-  analyzer: 0.13.4
 transformers:
 - polymer:
     entry_points: web/spark_polymer.html


### PR DESCRIPTION
Upgrade the `bootjack` package to the latest version, and remove our explicit dependency on `dquery`. Remove the dependency override on the `analyzer` package in order to upgrade to the latest (0.13.5) version.

TBR
