### PR TITLE
upgrade cipher to the latest version

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   bignum: '>=0.0.5 <0.1.0'
   bootjack: '>=0.6.0 < 0.7.0'
   chrome: '>=0.5.3 <0.6.0'
-  cipher: '>=0.6.0 <0.7.0'
+  cipher: '>=0.7.0 <0.8.0'
   compiler_unsupported: 0.7.1
   crypto: any
   intl: any

--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -10,7 +10,6 @@ import 'package:archive/archive.dart' as arch;
 import 'package:grinder/grinder.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
-import 'package:polymer/builder.dart' as polymer;
 
 import 'webstore_client.dart';
 


### PR DESCRIPTION
Upgrade `cipher` to the latest version. I want to keep us tracking the more recent versions of packages, to reduce the amount of unnoticed technical debt that we accumulate.

TBR
