### PR TITLE
fix dart template, web server regressions

### DIFF
--- a/ide/app/lib/launch.dart
+++ b/ide/app/lib/launch.dart
@@ -228,6 +228,8 @@ class ChromeAppLaunchDelegate extends LaunchDelegate {
  * A servlet that can serve `package:` urls (`/packages/`).
  */
 class PackagesServlet extends PicoServlet {
+  static const PACKAGE_SEGMENT = '/packages/';
+
   LaunchManager _launchManager;
 
   PackagesServlet(this._launchManager);
@@ -241,10 +243,12 @@ class PackagesServlet extends PicoServlet {
     Container project = _launchManager.workspace.getChild(projectName);
 
     if (project is Project) {
-      // TODO(ussuri): Switch to MetaPackageManager as soon as it's done.
-      PackageResolver resolver =
-          _launchManager._pubManager.getResolverFor(project);
-      File file = resolver.resolveRefToFile(_getPath(request));
+      // Convert a 'foo/packages/bar.dart' url into a 'package:bar.dart' one.
+      String path = _getPath(request);
+      path = 'package:' + path.substring(
+          path.indexOf(PACKAGE_SEGMENT) + PACKAGE_SEGMENT.length);
+      PackageResolver resolver = _launchManager._pubManager.getResolverFor(project);
+      File file = resolver.resolveRefToFile(path);
       if (file != null) {
         return _serveFileResponse(file);
       }

--- a/ide/app/resources/templates/web-dart/web/source.html_
+++ b/ide/app/resources/templates/web-dart/web/source.html_
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>``projectName``</title>
-    <link rel="stylesheet" href="_source_name_.css">
+    <link rel="stylesheet" href="``sourceName``.css">
   </head>
   <body>
-    <script type="application/dart" src="_source_name_.dart"></script>
+    <script type="application/dart" src="``sourceName``.dart"></script>
     <script src="packages/browser/dart.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Fix 2 regressions:
- the dart web app template was not getting its variables substituted properly
- the web server was not resolving `/packages/` references, and was serving up 401s

@ussuri
