### PR TITLE
Remove the no-longer-used /content/ selector from widgets' CSS

### DIFF
--- a/widgets/lib/spark_menu/spark_menu.css
+++ b/widgets/lib/spark_menu/spark_menu.css
@@ -18,18 +18,8 @@
   cursor: default;
   box-sizing: border-box;
 }
-* /content/ spark-menu-item, * /content/ spark-menu-separator {
-  display: block;
-  min-width: 160px;
-  cursor: default;
-  box-sizing: border-box;
-}
 
 ::content spark-menu-item {
-  min-height: 30px;
-  border: none;
-}
-* /content/ spark-menu-item {
   min-height: 30px;
   border: none;
 }
@@ -37,37 +27,21 @@
 ::content spark-menu-item.selected {
   background-color: #1a64a3;
 }
-* /content/ spark-menu-item.selected {
-  background-color: #1a64a3;
-}
 
 ::content spark-menu-item.selected ^ * {
-  color: white;
-}
-* /content/ spark-menu-item.selected /shadow/ * {
   color: white;
 }
 
 ::content spark-menu-item.active {
   background-color: #3a84c3;
 }
-* /content/ spark-menu-item.active {
-  background-color: #3a84c3;
-}
 
 ::content spark-menu-item.active ^ * {
-  color: white;
-}
-* /content/ spark-menu-item.active /shadow/ * {
   color: white;
 }
 
 /*@polyfill spark-menu-separator */
 ::content spark-menu-separator {
-  height: 2px;
-  margin: 2px 0px;
-}
-* /content/ spark-menu-separator {
   height: 2px;
   margin: 2px 0px;
 }

--- a/widgets/lib/spark_split_view/spark_split_view.css
+++ b/widgets/lib/spark_split_view/spark_split_view.css
@@ -19,9 +19,6 @@
 ::content > * {
   position: relative;
 }
-* /content/ * {
-  position: relative;
-}
 
 /* Make the passive target of resizing 'flex', so it auto-adjusts when the
    active target is resized.

--- a/widgets/lib/spark_toolbar/spark_toolbar.css
+++ b/widgets/lib/spark_toolbar/spark_toolbar.css
@@ -31,18 +31,9 @@
 ::content > * {
   margin: 0 4px;
 }
-* /content/ * {
-  margin: 0 4px;
-}
 
 /*@polyfill .toolbar > .flex */
 ::content > .flex {
-  -webkit-box-flex: 1;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-* /content/ .flex {
   -webkit-box-flex: 1;
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -64,9 +55,6 @@
 
   /*@polyfill .toolbar > *.hidden-narrow */
   ::content .hidden-narrow {
-    display: none;
-  }
-  * /content/ .hidden-narrow {
     display: none;
   }
 }


### PR DESCRIPTION
The /content/ has been very short-lived. It's not replaced back with ::content.

TBR
