### PR TITLE
Add new shadow DOM CSS selectors to restore menu items style in Chrome 36

### DIFF
--- a/widgets/lib/spark_menu/spark_menu.css
+++ b/widgets/lib/spark_menu/spark_menu.css
@@ -28,7 +28,11 @@
   background-color: #1a64a3;
 }
 
+/* BUG #1569 */
 ::content spark-menu-item.selected ^ * {
+  color: white;
+}
+::content spark-menu-item.selected /deep/ * {
   color: white;
 }
 
@@ -36,7 +40,11 @@
   background-color: #3a84c3;
 }
 
+/* BUG #1569 */
 ::content spark-menu-item.active ^ * {
+  color: white;
+}
+::content spark-menu-item.active /deep/ * {
   color: white;
 }
 


### PR DESCRIPTION
See details in #1569.

TBR
