### PR TITLE
Print disambiguating message for grind's [lint] step

### DIFF
--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -85,6 +85,7 @@ void setup(GrinderContext context) {
 void lint(context) {
   // TODO(devoncarew): Commented out to work around an NPE in the polymer linter.
   //polymer.lint(entryPoints: ['app/spark_polymer.html']);
+  print('  !!! lint is temporarily turned off');
 }
 
 /**


### PR DESCRIPTION
TBR: @devoncarew

Even though the actual linting had been disabled, lint was still printing the step's name, [lint], which could leave an impression that there were no errors.
