### PR TITLE
Throw auth_failure while cloning if credentials are needed.

### DIFF
--- a/ide/app/lib/git/commands/clone.dart
+++ b/ide/app/lib/git/commands/clone.dart
@@ -11,6 +11,7 @@ import 'package:chrome/chrome_app.dart' as chrome;
 
 import '../config.dart';
 import '../constants.dart';
+import '../exception.dart';
 import '../fast_sha.dart';
 import '../file_operations.dart';
 import '../http_fetcher.dart';
@@ -65,7 +66,7 @@ class Clone {
       } else if (!url.endsWith('.git')) {
         return _clone(url + '.git');
       } else {
-        return new Future.error('Invalid git repository url.');
+        return new GitException(GitErrorConstants.GIT_REPO_NOT_FOUND);
       }
     });
   }

--- a/ide/app/lib/git/exception.dart
+++ b/ide/app/lib/git/exception.dart
@@ -44,4 +44,10 @@ class GitErrorConstants {
 
   static final String GIT_COMMIT_NO_CHANGES
       = "git.commit_no_changes";
+
+  static final String GIT_AUTH_FAILURE
+      = "git.auth_failure";
+
+  static final String GIT_REPO_NOT_FOUND
+      = "git.repo_not_found";
 }

--- a/ide/app/lib/git/http_fetcher.dart
+++ b/ide/app/lib/git/http_fetcher.dart
@@ -11,6 +11,7 @@ import 'dart:html';
 import 'dart:typed_data';
 
 import 'objectstore.dart';
+import 'exception.dart';
 import 'upload_pack_parser.dart';
 
 final int COMMIT_LIMIT = 32;
@@ -198,7 +199,12 @@ class HttpFetcher {
    */
   Future<bool> isValidRepoUrl(String url) {
     String uri = _makeUri('/info/refs', {"service": 'git-upload-pack'});
-    return _doGet(uri).then((_) => true).catchError((e) => false);
+    return _doGet(uri).then((_) => true).catchError((e) {
+      if (e.status == 401) {
+        throw new GitException(GitErrorConstants.GIT_AUTH_FAILURE);
+      }
+      return false;
+    });
   }
 
   String _makeUri(String path, Map<String, String> extraOptions) {

--- a/ide/app/lib/scm.dart
+++ b/ide/app/lib/scm.dart
@@ -19,6 +19,7 @@ import 'builder.dart';
 import 'jobs.dart';
 import 'workspace.dart';
 import 'git/config.dart';
+import 'git/exception.dart';
 import 'git/http_fetcher.dart';
 import 'git/objectstore.dart';
 import 'git/object.dart';
@@ -273,6 +274,8 @@ class GitScmProvider extends ScmProvider {
     }).catchError((e) {
       if (e is HttpResult) {
         throw new ScmException(e.toString(), e.needsAuth);
+      } else if (e is GitException) {
+        throw new ScmException(e.toString(), true);
       } else {
         throw new ScmException(e.toString());
       }


### PR DESCRIPTION
Percolate the authentifcation exception to the SCM layer in git clone.

The SCM layer should catch the exception and ask for the git credentials if not yet provided. 
(We can support private repositories with this.)

@devoncarew 
