### PR TITLE
Disable SCM for imported folders (using .git/index and not .git/index2)

### DIFF
--- a/ide/app/lib/scm.dart
+++ b/ide/app/lib/scm.dart
@@ -250,15 +250,9 @@ class GitScmProvider extends ScmProvider {
 
   bool isUnderScm(Project project) {
     Folder gitFolder = project.getChild('.git');
-    if (!(gitFolder is Folder)) {
-      return false;
-    }
-
-    if ((gitFolder.getChild('index2') is File) &&
-        (!(gitFolder.getChild('index') is File))) {
-      return false;
-    }
-
+    if (gitFolder is! Folder) return false;
+    if (gitFolder.getChild('index2') is! File) return false;
+    if (gitFolder.getChild('index') is File) return false;
     return true;
   }
 


### PR DESCRIPTION
review: @grv @devoncarew
