### PR TITLE
Fix spark-menu-button not opening menu on click

### DIFF
--- a/widgets/lib/spark_menu_button/spark_menu_button.dart
+++ b/widgets/lib/spark_menu_button/spark_menu_button.dart
@@ -40,11 +40,9 @@ class SparkMenuButton extends SparkWidget {
     if (inOpened != opened) {
       opened = inOpened;
       // TODO(ussuri): A temporary plug to make spark-overlay see changes
-      // in 'opened' when run as deployed code. Just binding via {{opened}}
-      // alone isn't detected and the menu doesn't open.
-      if (IS_DART2JS) {
-        _overlay.opened = opened;
-      }
+      // in 'opened'. Just binding via {{opened}} alone isn't detected and the
+      // menu doesn't open.
+      _overlay.opened = opened;
       if (opened) {
         // Enforce focused state so the button can accept keyboard events.
         focus();


### PR DESCRIPTION
TBR @jmesserly: John, any word of wisdom as to why data binding doesn't work here on its own would be appreciated.

The fix that was previously required for the deployed code to work is now required in undeployed code too: the direct assignment of the contained spark-overlay's `opened` attribute; auto-assignment via a data binding doesn't work.
