### PR TITLE
Update index while creating file in git clone.

### DIFF
--- a/ide/app/lib/git/commands/checkout.dart
+++ b/ide/app/lib/git/commands/checkout.dart
@@ -44,9 +44,8 @@ class Checkout {
                   (CommitObject commit) {
                 return ObjectUtils.expandTree(root, store, commit.treeSha)
                     .then((_) {
-                  store.index.reset(false).then((_) {
-                    return store.setHeadRef(REFS_HEADS + branch, '');
-                  });
+                  store.index.reset(false);
+                  return store.setHeadRef(REFS_HEADS + branch, '');
                 });
               });
             });

--- a/ide/app/lib/git/commands/clone.dart
+++ b/ide/app/lib/git/commands/clone.dart
@@ -238,9 +238,7 @@ class Clone {
                 return _createInitialConfig(result.shallow, localHeadRef)
                     .then((_) {
                   logger.info(_stopwatch.finishCurrentTask('createInitialConfig'));
-                  return _options.store.index.reset(true).then((_) {
-                    logger.info(_stopwatch.finishCurrentTask('index.reset()'));
-                  });
+                  _options.store.index.reset(true);
                 });
               });
             });

--- a/ide/app/lib/git/commands/index.dart
+++ b/ide/app/lib/git/commands/index.dart
@@ -98,8 +98,7 @@ class Index {
   }
 
   // TODO(grv) : remove this after index file implementation.
-  Future reset([bool isFirstRun]) {
-    return walkFilesAndUpdateIndex(_store.root).then((_) {
+  void reset([bool isFirstRun]) {
       _statusIdx.forEach((String key, FileStatus status) {
         if (status.type != FileStatusType.UNTRACKED || isFirstRun != null) {
           status.type = FileStatusType.COMMITTED;
@@ -107,7 +106,6 @@ class Index {
         status.headSha = status.sha;
       });
       _scheduleWriteIndex();
-    });
   }
 
   Future updateIndex() {
@@ -127,7 +125,8 @@ class Index {
           _statusIdx = _parseIndex(out);
         });
       }, onError: (e) {
-        return reset(true);
+        reset(true);
+        return new Future.value();
       });
     });
   }

--- a/ide/app/lib/git/object_utils.dart
+++ b/ide/app/lib/git/object_utils.dart
@@ -10,6 +10,7 @@ import 'dart:core';
 import 'package:chrome/chrome_app.dart' as chrome;
 
 import 'file_operations.dart';
+import 'commands/index.dart';
 import 'object.dart';
 import 'objectstore.dart';
 
@@ -84,7 +85,15 @@ abstract class ObjectUtils {
     return store.retrieveObject(blobSha, ObjectTypes.BLOB_STR).then(
         (BlobObject blob) {
       return FileOps.createFileWithContent(dir, fileName, blob.data,
-          ObjectTypes.BLOB_STR);
+          ObjectTypes.BLOB_STR).then((chrome.Entry entry) {
+        return entry.getMetadata().then((data) {
+          FileStatus status = new FileStatus();
+          status.path = entry.fullPath;
+          status.sha = blobSha;
+          status.size = data.size;
+          store.index.updateIndexForEntry(status);
+        });
+      });
     });
   }
 


### PR DESCRIPTION
Update the git-index while we are creating the files. This avoid re-calculating the sha values of the files again.

This optimizes git clone by 15-20% (spark checkout taking 43-46 secs now as compared to 55-58 secs before).

@devoncarew 
