### PR TITLE
Continue stripping trailing whitespace to file without affecting cursor

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -139,7 +139,7 @@ class TextEditor extends Editor {
       //           but it might be a good idea to do so rather than passing it.
 
       String text = _session.value;
-      if (stripWhitespace) text = _stripWhitespace(text);
+      if (stripWhitespace) text = text.replaceAll(whitespaceRegEx, '');
       _lastSavedHash = _calcMD5(text);
 
       // TODO(ericarnold): Need to cache or re-analyze on file switch.
@@ -150,10 +150,6 @@ class TextEditor extends Editor {
     } else {
       return new Future.value();
     }
-  }
-
-  String _stripWhitespace(String text) {
-    return text.replaceAll(whitespaceRegEx, '');
   }
 
   /**


### PR DESCRIPTION
This fixes a problem with the cursor jumping when typing too slowly with indentations or intentional trailing spaces.

Review @dinhviethoa 
