### PR TITLE
override ace's gotoline command; remove an unused action

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -277,6 +277,13 @@ class AceManager {
     _aceEditor.setOption('enableBasicAutocompletion', true);
     _aceEditor.setOption('enableSnippets', true);
 
+    // Override Ace's gotoline command.
+    var command = new ace.Command(
+        'gotoline',
+        const ace.BindKey(mac: 'Command-L', win: 'Ctrl-L'),
+        (e) => _handleGotoLine());
+    _aceEditor.commands.addCommand(command);
+
     // Fallback
     theme = THEMES[0];
 
@@ -371,12 +378,15 @@ class AceManager {
           currentSession.documentToScreenRow(marker.lineNum, aceColumn)
           / numberLines * 100.0;
 
-      html.Element minimapMarker = new html.Element.div();
-      minimapMarker.classes.add("minimap-marker ${marker.severityDescription}");
-      minimapMarker.style.top = '${markerPos.toStringAsFixed(2)}%';
-      minimapMarker.onClick.listen((e) => _miniMapMarkerClicked(e, marker));
+      // Only add errors and warnings to the mini-map.
+      if (marker.severity >= workspace.Marker.SEVERITY_WARNING) {
+        html.Element minimapMarker = new html.Element.div();
+        minimapMarker.classes.add("minimap-marker ${marker.severityDescription}");
+        minimapMarker.style.top = '${markerPos.toStringAsFixed(2)}%';
+        minimapMarker.onClick.listen((e) => _miniMapMarkerClicked(e, marker));
 
-      minimap.append(minimapMarker);
+        minimap.append(minimapMarker);
+      }
     }
 
     currentSession.setAnnotations(annotations);
@@ -600,6 +610,11 @@ class AceManager {
       default:
         return ace.Annotation.INFO;
     }
+  }
+
+  void _handleGotoLine() {
+    // TODO(devoncarew): Show a 'goto line' dialog.
+    //print('_handleGotoLine');
   }
 }
 

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -383,7 +383,6 @@ abstract class Spark
     actionManager.registerAction(new FolderNewAction(this, getDialogElement('#folderNewDialog')));
     actionManager.registerAction(new FolderOpenAction(this));
     actionManager.registerAction(new NewProjectAction(this, getDialogElement('#newProjectDialog')));
-    actionManager.registerAction(new FileOpenInTabAction(this));
     actionManager.registerAction(new FileSaveAction(this));
     actionManager.registerAction(new PubGetAction(this));
     actionManager.registerAction(new PubUpgradeAction(this));
@@ -1053,22 +1052,6 @@ abstract class SparkActionWithDialog extends SparkAction {
   }
 
   void _show() => _dialog.show();
-}
-
-class FileOpenInTabAction extends SparkAction implements ContextAction {
-  FileOpenInTabAction(Spark spark) :
-      super(spark, "file-open-in-tab", "Open in New Tab");
-
-  void _invoke([List<ws.File> files]) {
-    bool forceOpen = files.length > 1;
-    files.forEach((ws.File file) {
-      spark._selectInEditor(file, forceOpen: true, replaceCurrent: false);
-    });
-  }
-
-  String get category => 'folder';
-
-  bool appliesTo(Object object) => _isFileList(object);
 }
 
 class FileOpenAction extends SparkAction {


### PR DESCRIPTION
misc Ace work:
- override Ace's default action for goto line - it throws an exception (due to CSP)
- don't show info level markers in the minimap (things like todo comments - it's too busy)
- remove the `FileOpenInTabAction` action - it's not used anymore with our new tab behavior

@dinhviethoa @umop
