### PR TITLE
Get-declaration key binding for ChromeOS

### DIFF
--- a/ide/app/lib/actions.dart
+++ b/ide/app/lib/actions.dart
@@ -192,9 +192,12 @@ class KeyBinding {
           "F11": KeyCode.F11,
           "F12": KeyCode.F12,
 
+          "SPACE": KeyCode.SPACE,
+          "ENTER": KeyCode.ENTER,
           "TAB": KeyCode.TAB,
           "[" : KeyCode.OPEN_SQUARE_BRACKET,
-          "]" : KeyCode.CLOSE_SQUARE_BRACKET
+          "]" : KeyCode.CLOSE_SQUARE_BRACKET,
+          ".": KeyCode.PERIOD
       };
     }
     return __bindingMap;

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -1561,7 +1561,7 @@ class GetDeclarationAction extends SparkAction {
 
   GetDeclarationAction(Spark spark)
       : super(spark, 'getDeclaration', 'Get Declaration') {
-    addBinding('f3');
+    addBinding('ctrl-.');
     _analysisService = spark.services.getService('analyzer');
   }
 


### PR DESCRIPTION
Added several key binding shortcuts in actions.dart and changed link-to-declaration to use ctrl + . for now (since chrome OS has no quick F3).

Fixes #1701 

Review @devoncarew 
