### PR TITLE
Deploy via USB can now communicate with a local ADB server

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -1748,8 +1748,8 @@ class _HarnessPushJob extends Job {
     HarnessPush harnessPush = new HarnessPush(deployContainer,
         spark.localPrefs);
 
-    Future push = _adb ? harnessPush.pushADB(monitor) :
-        harnessPush.push(_url, monitor);
+    Future push = _adb ? harnessPush.pushAdb(monitor) :
+        harnessPush.pushToHost(_url, monitor);
     return push.then((_) {
       if (_adb) {
         spark.hideProgressDialog();


### PR DESCRIPTION
If the ADB server is already running, Spark will use that to deploy to
mobile instead of its custom USB code. This avoids fighting with ADB
over the USB interface.

Chrome DevTools likewise uses the system's ADB server if it exists, so
when the ADB server is running Spark and DevTools coexist peacefully.

On Chromebooks, nothing has changed.

@devoncarew for review.
