### PR TITLE
Find re-position to left side

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -264,8 +264,6 @@ class AceManager {
     _aceEditor.printMarginColumn = 80;
     _aceEditor.readOnly = true;
     _aceEditor.fadeFoldWidgets = true;
-    html.DivElement searchBox =
-        parentElement.getElementsByClassName("ace_search")[0];
 
     _analysisService =  services.getService("analyzer");
 

--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -91,6 +91,7 @@ div.ace_gutter-cell.ace_info {
   color: #9CC;
 }
 
+/* TODO: Remove when find bar has been implemented natively in Spark */
 div.ace_search.right {
   margin: 5px;
   border-radius: 0px 0px 5px 0px;


### PR DESCRIPTION
This repositions the find box to the left side temporarily.

Fixes #1602

@dinhviethoa @devoncarew
