### PR TITLE
work on ace tooltips

### DIFF
--- a/ide/.gitignore
+++ b/ide/.gitignore
@@ -1,5 +1,6 @@
 .settings/
 app/app.json
+app/user.json
 app/lib/mobile/nacl_android_rsa.nmf
 app/lib/mobile/nacl_android_rsa.pexe
 app/spark.dart.js

--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -367,7 +367,7 @@ class AceManager {
   String _formatAnnotationItemText(String text, [String type]) {
     if (type == null) return text;
 
-    return "<img src='images/${type}_icon.png'> ${text}";
+    return "<img class='ace-tooltip' src='images/${type}_icon.png'> ${text}";
   }
 
   void setMarkers(List<workspace.Marker> markers) {

--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -79,6 +79,13 @@ div.ace_gutter-cell.ace_info, .ace_dark div.ace_gutter-cell.ace_info {
   margin: 3px -4px;
 }
 
+img.ace-tooltip {
+  border: none;
+  display: inline;
+  margin-left: 3px;
+  margin-bottom: 3px;
+}
+
 div.ace_search {
   background: #fafafa;
   padding-right: 4px;


### PR DESCRIPTION
Fix an issue where tooltips for warnings displayed yellow text on a white background.

![screen shot 2014-05-08 at 3 11 20 am](https://cloud.githubusercontent.com/assets/1269969/2914968/e4cf0324-d6a4-11e3-9277-a2c65a067642.png)

This CL:

![screen shot 2014-05-08 at 4 25 40 am](https://cloud.githubusercontent.com/assets/1269969/2914972/f1e78284-d6a4-11e3-9938-ad8d0b00f3da.png)

Also fixes #1790.

@umop, @dinhviethoa
