### PR TITLE
Fix spark-button: noPadding attribute didn't work when set programmatically (vs. statically)

### DIFF
--- a/widgets/lib/spark_button/spark_button.dart
+++ b/widgets/lib/spark_button/spark_button.dart
@@ -4,6 +4,8 @@
 
 library spark_widgets.button;
 
+import 'dart:html';
+
 import 'package:polymer/polymer.dart';
 
 import '../common/spark_widget.dart';
@@ -17,16 +19,20 @@ class SparkButton extends SparkWidget {
   @published bool enabled = true;
   @published bool active = false;
 
+  ButtonElement _button;
+
   SparkButton.created() : super.created();
 
   @override
   void enteredView() {
-    _setClasses();
-    changes.listen((_) => _setClasses());
+    _button = $['button'];
+
+    _refresh();
+    changes.listen((_) => _refresh());
   }
 
-  void _setClasses() {
-    $['button'].classes
+  void _refresh() {
+    _button.classes
         ..toggle('btn-primary', primary)
         ..toggle('btn-default', !primary)
         ..toggle('disabled', !enabled)
@@ -34,5 +40,6 @@ class SparkButton extends SparkWidget {
         ..toggle('btn-sm', small)
         ..toggle('enabled', enabled)
         ..toggle('active', active);
+    _button.style.padding = noPadding ? '0' : null;
   }
 }

--- a/widgets/lib/spark_button/spark_button.html
+++ b/widgets/lib/spark_button/spark_button.html
@@ -15,13 +15,6 @@
                 active">
   <template>
     <link rel="stylesheet" href="spark_button.css">
-    <template if="{{noPadding}}">
-      <style>
-        #button {
-          padding: 0;
-        }
-      </style>
-    </template>
 
     <button id="button" type="button" class="btn" focused>
       <content></content>


### PR DESCRIPTION
TBR

This worked:
  HTML: `<spark-button noPadding></>`
But this didn't:
  HTML: `<spark-button id="btn"></>`
  Dart: `(querySelector('#btn') as SparkButton).noPadding = true;`

The reason was the half-working support for data-binding in an inline <style> tag in a Polymer custom element's markup: when used around an inline <style> tag, <template if="{{noPadding}}"> worked for statically set noPadding, but failed to see programmatic changes to it, as described above.
