### PR TITLE
Outline member full width 

### DIFF
--- a/ide/app/lib/outline.dart
+++ b/ide/app/lib/outline.dart
@@ -216,7 +216,7 @@ abstract class OutlineItem {
     _element.classes.add("outlineItem $cssClassName");
   }
 
-  Stream get onClick => _element.onClick;
+  Stream get onClick => _anchor.onClick;
   int get nameStartOffset => _data.nameStartOffset;
   int get nameEndOffset => _data.nameEndOffset;
   int get bodyStartOffset => _data.bodyStartOffset;

--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -373,13 +373,13 @@ button.ace_searchbtn_close:active {
   border-radius: 5px;
 }
 
+.outlineItem >a {
+  display: block;
+}
+
 .outlineItem {
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.outlineItem:hover > a {
-  text-decoration: underline;
 }
 
 .outlineItem.selected {


### PR DESCRIPTION
This fixes the outline items to take up the entire width of the outline for better discovery of clickability.

@dinhviethoa @devoncarew

Fixes #1837
