### PR TITLE
add a send feedback button

### DIFF
--- a/ide/app/lib/templates/templates.dart
+++ b/ide/app/lib/templates/templates.dart
@@ -69,6 +69,9 @@ class ProjectBuilder {
       if (r != null) return r;
     }
 
+    r = project.getChild('index.html');
+    if (r != null) return r;
+
     return project;
   }
 }

--- a/ide/app/spark_polymer_ui.dart
+++ b/ide/app/spark_polymer_ui.dart
@@ -94,6 +94,10 @@ class SparkPolymerUI extends SparkWidget {
     _model.setGitSettingsResetDoneVisible(true);
   }
 
+  void onSendFeedback() {
+    window.open('https://github.com/dart-lang/spark/issues/new', '_blank');
+  }
+
   void onResetPreference() {
     Element resultElement = getShadowDomElement('#preferenceResetResult');
     resultElement.text = '';

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -403,6 +403,11 @@
             </label>
           </div>
         </div>
+        <div class="form-group">
+          <spark-button on-click="{{onSendFeedback}}">
+            Send feedback about Spark...
+          </spark-button>
+        </div>
       </div>
       <div class="modal-footer">
         <spark-button overlay-toggle primary focused data-dismiss="modal">
@@ -512,7 +517,6 @@
             </div>
           </div>
         </template>
-
       </div>
       <div class="modal-footer">
         <spark-button overlay-toggle primary focused data-dismiss="modal">


### PR DESCRIPTION
@ussuri, add a `Send Feedback` button to Spark's about box. I experimented with having it in the spark menu, but that menu's getting a bit long - I want to be careful of what goes in there.

Also, changed our template code so that templates that have an `index.html` at the top level - and no other entry point - open that when a new project is created.

![screen shot 2014-05-14 at 1 40 58 pm](https://cloud.githubusercontent.com/assets/1269969/2977266/678a34ce-dba9-11e3-9e1f-3ade86558671.png)
