### PR TITLE
fix a refresh issue

### DIFF
--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -1064,7 +1064,8 @@ class Project extends Folder {
 
   Future refresh() {
     // Only allow one refresh call at a time.
-    assert(_inRefresh == false);
+    if (_inRefresh) return new Future.value();
+
     _inRefresh = true;
 
     workspace.pauseResourceEvents();


### PR DESCRIPTION
Remove an assert that was triggered when switching to and from applications quickly. Changed our semantics to only only one refresh at a time, but not throw an assert about it.
