### PR TITLE
Fix mouse not reacting to hovering over the right half of #draggable (overlapping editor panel)

### DIFF
--- a/widgets/lib/spark_splitter/spark_splitter.css
+++ b/widgets/lib/spark_splitter/spark_splitter.css
@@ -33,6 +33,11 @@
 #draggable {
   position: absolute;
   z-index: 1;
+  /* With fully transparent #draggable, the mouse sometimes didn't react
+     to hovering over it, depending on the surrounding elements. A CSS bug?
+  */
+  background-color: white;
+  opacity: 0.001;
 }
 
 :host(.vertical:host) #draggable {


### PR DESCRIPTION
TBR: @dinhviethoa
