### PR TITLE
move the send feedback action

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -454,6 +454,7 @@ abstract class Spark
     actionManager.registerAction(new HistoryAction.back(this));
     actionManager.registerAction(new HistoryAction.forward(this));
     actionManager.registerAction(new ToggleOutlineVisibilityAction(this));
+    actionManager.registerAction(new SendFeedbackAction(this));
 
     actionManager.registerKeyListener();
   }
@@ -3184,6 +3185,15 @@ class ToggleOutlineVisibilityAction extends SparkAction {
   @override
   void _invoke([Object context]) {
     spark._aceManager.outline.toggle();
+  }
+}
+
+class SendFeedbackAction extends SparkAction {
+  SendFeedbackAction(Spark spark)
+      : super(spark, 'send-feedback', 'Send Feedback…');
+
+  void _invoke([context]) {
+    window.open('https://github.com/dart-lang/spark/issues/new', '_blank');
   }
 }
 

--- a/ide/app/spark_polymer.html
+++ b/ide/app/spark_polymer.html
@@ -110,27 +110,36 @@
             valign="left">
           <spark-menu-item action-id="project-new" label="New Project...">
           </spark-menu-item>
+
           <spark-menu-separator></spark-menu-separator>
+
           <spark-menu-item action-id="file-open" label="Open File...">
           </spark-menu-item>
           <spark-menu-item action-id="folder-open" label="Open Folder...">
           </spark-menu-item>
           <spark-menu-item action-id="git-clone" label="Git Clone...">
           </spark-menu-item>
+
           <spark-menu-separator></spark-menu-separator>
+
           <spark-menu-item action-id="application-run" label="Run Application">
           </spark-menu-item>
           <spark-menu-item action-id="application-push" label="Deploy to Mobile...">
           </spark-menu-item>
           <spark-menu-item action-id="webstore-publish" label="Publish to Chrome Web Store...">
           </spark-menu-item>
+
           <template if="{{developerMode}}">
             <spark-menu-separator></spark-menu-separator>
             <spark-menu-item action-id="run-tests" label="Run Tests">
             </spark-menu-item>
           </template>
+
           <spark-menu-separator></spark-menu-separator>
+
           <spark-menu-item action-id="settings" label="Settings...">
+          </spark-menu-item>
+          <spark-menu-item action-id="send-feedback" label="Send Feedback...">
           </spark-menu-item>
           <spark-menu-item action-id="help-about" label="About Spark">
           </spark-menu-item>

--- a/ide/app/spark_polymer_ui.dart
+++ b/ide/app/spark_polymer_ui.dart
@@ -102,10 +102,6 @@ class SparkPolymerUI extends SparkWidget {
     _model.setGitSettingsResetDoneVisible(true);
   }
 
-  void onSendFeedback() {
-    window.open('https://github.com/dart-lang/spark/issues/new', '_blank');
-  }
-
   void onResetPreference() {
     Element resultElement = getShadowDomElement('#preferenceResetResult');
     resultElement.text = '';

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -412,11 +412,6 @@
             </label>
           </div>
         </div>
-        <div class="form-group">
-          <spark-button on-click="{{onSendFeedback}}">
-            Send feedback about Spark...
-          </spark-button>
-        </div>
       </div>
       <div class="modal-footer">
         <spark-button overlay-toggle primary focused data-dismiss="modal">


### PR DESCRIPTION
Move the `Send Feedback` action from the about box to an item on the main spark menu, in order to make it more discoverable.

(TBR)
