### PR TITLE
ace.dart/lib/src/command.dart did not show up until after 0.3.6

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/spark/
 environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
-  ace: '>=0.3.5 <0.4.0'
+  ace: '>=0.3.6 <0.4.0'
   analyzer: '>=0.13.0 <0.14.0'
   archive: '>=1.0.16 <1.1.0'
   barback: any


### PR DESCRIPTION
Had some issues with pub just now. The `ace.BindKey` class showed up after 0.3.5, so changing the minimum version will help others. 
