### PR TITLE
fix issues with closing dialogs

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -1130,7 +1130,6 @@ abstract class SparkActionWithDialog extends SparkAction {
                         Element dialogElement)
       : super(spark, id, name) {
     _dialog = spark.createDialog(dialogElement);
-    _dialog.element.querySelector("a.close").onClick.listen((_) => _cancel());
     _dialog.element.querySelector("[primary]").onClick.listen((_) => _commit());
   }
 
@@ -1945,8 +1944,6 @@ class DeployToMobileAction extends SparkActionWithDialog implements ContextActio
     enabled = false;
     spark.focusManager.onResourceChange.listen((r) => _updateEnablement(r));
 
-    getElement(".modal-footer spark-button").onClick.listen((_) => _cancel());
-
     // When the IP address field is selected, check the `IP` checkbox.
     getElement('#pushUrl').onFocus.listen((e) {
       (getElement('#ip') as InputElement).checked = true;
@@ -2090,6 +2087,8 @@ class PropertiesAction extends SparkActionWithDialog implements ContextAction {
     _propertiesElement.innerHtml = '';
     _buildProperties().then((_) => _show());
   }
+
+  void _commit() => _hide();
 
   Future _buildProperties() {
     _addProperty(_propertiesElement, 'Name', _selectedResource.name);
@@ -2958,6 +2957,8 @@ class AboutSparkAction extends SparkActionWithDialog {
 
     _show();
   }
+
+  void _commit() => _hide();
 }
 
 class SettingsAction extends SparkActionWithDialog {
@@ -2996,6 +2997,8 @@ class SettingsAction extends SparkActionWithDialog {
       });
     });
   }
+
+  void _commit() => _hide();
 
   Future _showRootDirectory() {
     return spark.localPrefs.getValue('projectFolder').then((folderToken) {

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -212,7 +212,7 @@
     <!-- Harness Push dialog -->
     <spark-modal id="mobileDeployDialog" class="dialog" animation="scale-slideup">
       <div class="modal-header">
-        <a href="#" class="close">&times;</a>
+        <a href="#" class="close" overlay-toggle>&times;</a>
         <h4 class="modal-title">Deploy to Mobile</h4>
       </div>
       <div class="modal-body">
@@ -246,7 +246,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <spark-button>
+        <spark-button overlay-toggle data-dismiss="modal">
           Cancel
         </spark-button>
         <spark-button primary focused>


### PR DESCRIPTION
Partially roll back a previous CL (https://github.com/dart-lang/spark/pull/1995/files). This caused issues closing dialogs. I'm not sure what the issue is, but it looks like listening on the `a.close` elements causes their `overlay-toggle` behavior to not work.

There are still problems with `Close` on the about box and the settings dialog (https://github.com/dart-lang/spark/issues/2028).

@ussuri
