### PR TITLE
Devoncarew disable drone

### DIFF
--- a/ide/tool/drone_io.sh
+++ b/ide/tool/drone_io.sh
@@ -33,6 +33,7 @@ if [ "$DRONE" = "true" ]; then
   # TODO(devoncarew): disable dart2js tests on drone...
   # https://github.com/dart-lang/spark/issues/2054
   #dart tool/test_runner.dart --dartium --appPath=build/deploy-out/web
+  echo "testing of JavaScript version temporarily disabled (#2054)"
 else
   dart tool/test_runner.dart --chrome
 fi


### PR DESCRIPTION
Disable JS tests on drone, so we at least have test coverage of the dartium version. Will continue investigating https://github.com/dart-lang/spark/issues/2054.

@dinhviethoa
