### PR TITLE
New Dartium: fix editor panel resizing randomly when switching between files

### DIFF
--- a/ide/app/lib/ui/widgets/tabview.css
+++ b/ide/app/lib/ui/widgets/tabview.css
@@ -134,7 +134,11 @@
   display: none;
   flex: 1;
   overflow: hidden;
-  position: relative;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }
 
 .tabview-page-container-active {


### PR DESCRIPTION
@dinhviethoa

The problem looked like this:

![screen shot 2014-05-26 at 1 57 27 am](https://cloud.githubusercontent.com/assets/5606182/3080671/fe7bc970-e4b3-11e3-8b62-af551696d82a.png)

![screen shot 2014-05-26 at 1 59 57 am](https://cloud.githubusercontent.com/assets/5606182/3080683/29d37bae-e4b4-11e3-8797-a4228da5ea54.png)

The duplicate selection in the file tree view still remains - I didn't look into it.
