### PR TITLE
Special `template if="{{...}}"` within <option> tag didn't work

### DIFF
--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -255,28 +255,29 @@
               <option value="chrome/chrome_app_js">
                 JavaScript Chrome app
               </option>
-              <!-- This one currently can't possibly work due to Polymer
-                   JS breaking the CSP. BUG #1933. -->
-              <option value="chrome/chrome_app_polymer_js;polymer,polymer-elements,polymer-ui-elements"
-                   template if="{{showWipProjectTemplates}}">
-                JavaScript Chrome app using Polymer
-              </option>
-              <!-- This one works when installed in Chrome manually, but
-                   launching via the 'Run' button is broken. BUG #1935. -->
-              <option value="chrome/chrome_extension_js"
-                   template if="{{showWipProjectTemplates}}">
-                JavaScript Chrome extension
-              </option>
+              <template if="{{showWipProjectTemplates}}">
+                <!-- This one currently can't possibly work due to Polymer
+                     JS breaking the CSP. BUG #1933. -->
+                <option value="chrome/chrome_app_polymer_js;polymer,polymer-elements,polymer-ui-elements">
+                  JavaScript Chrome app using Polymer
+                </option>
+                <!-- This one works when installed in Chrome manually, but
+                     launching via the 'Run' button is broken. BUG #1935. -->
+                <option value="chrome/chrome_extension_js">
+                  JavaScript Chrome extension
+                </option>
+              </template>
             </optgroup>
             <optgroup label="Other">
               <option value="polymer/polymer_element_js">
                 JavaScript Polymer custom element
               </option>
-              <!-- This one just needs some additional work. -->
-              <option value="polymer/polymer_element_dart"
-                  template if="{{showWipProjectTemplates}}">
-                Dart Polymer custom element
-              </option>
+              <template if="{{showWipProjectTemplates}}">
+                <!-- This one just needs some additional work. -->
+                <option value="polymer/polymer_element_dart">
+                  Dart Polymer custom element
+                </option>
+              </template>
             </optgroup>
           </select>
         </div>


### PR DESCRIPTION
TBR

dart2js complains when it finds a `<template if>` within a `<select>` tag. An alternative method is reportedly the `template="{{...}}"` attribute right within an `<option>` tag. However, that didn't seem to work at least on Dartium. Better to have dart2js warnings than not working debugging code...
