### PR TITLE
Ignore .lock files from git status.

### DIFF
--- a/ide/app/lib/git/commands/status.dart
+++ b/ide/app/lib/git/commands/status.dart
@@ -40,7 +40,15 @@ class Status {
       // Dont't track status for new and untracked files unless explicitly
       // added.
       if (status == null) {
-        return new FileStatus();
+
+        status = new FileStatus();
+
+        // Ignore status of .lock files.
+        // TODO (grv) : Implement gitignore support.
+        if (entry.name.endsWith('.lock')) {
+          status.type = FileStatusType.COMMITTED;
+        }
+        return status;
       }
 
       // TODO(grv) : check the modification time when it is available.


### PR DESCRIPTION
.lock files shows up as modified when we checkout spark repository.

Ideally they should be configured to ignore in .gitignore file. Until that support is added, explicitly don't show status of .lock files.

@devoncarew 
