### PR TITLE
Switched from scaleZ to translateX to form stacking contexts: scaleZ butchered font rendering

### DIFF
--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -600,7 +600,3 @@ li.outlineItem a {
   transition: opacity 250ms;
   z-index: 100;
 }
-
-.tabview-workspace * {
-  -webkit-font-smoothing: antialiased;
-}

--- a/widgets/lib/common/spark_widget.css
+++ b/widgets/lib/common/spark_widget.css
@@ -25,8 +25,8 @@
 }
 
 .stacking-context {
-  /* This no-op scaleZ(1) creates an independent stacking context for :host. */
-  -webkit-transform: scaleZ(1);
+  /* This no-op transform creates an independent stacking context. */
+  -webkit-transform: translateX(0);
 }
 
 /* Uncomment these 2 rules, or selectively apply the .debug class or debug

--- a/widgets/lib/spark_overlay/spark_overlay.css
+++ b/widgets/lib/spark_overlay/spark_overlay.css
@@ -26,10 +26,10 @@
   outline: none;
   display: none;
   opacity: 0;
-  /* The no-op scaleZ(1) creates an independent stacking context for :host.
+  /* The no-op transform creates an independent stacking context for :host.
      See: https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/The_stacking_context
   */
-  -webkit-transform: scaleZ(1);
+  -webkit-transform: translateX(0);
 }
 
 /*

--- a/widgets/lib/spark_split_view/spark_split_view.css
+++ b/widgets/lib/spark_split_view/spark_split_view.css
@@ -6,8 +6,8 @@
 
 :host {
   display: flex;
-  /* Form an independent stacking context */
-  -webkit-transform: scaleZ(1);
+  /* The no-op transform forms an independent stacking context */
+  -webkit-transform: translateX(0);
 }
 
 :host([direction="left"]:host, [direction="right"]:host) {

--- a/widgets/lib/spark_splitter/spark_splitter.css
+++ b/widgets/lib/spark_splitter/spark_splitter.css
@@ -7,12 +7,10 @@
 :host {
   background-color: #dadada;
   display: block;
+  /* Form an independent stacking context. */
   position: relative;
-  /* Set a identity transform to make <spark-splitter> to be a stacking context.
-     Then, z-index in #draggable becomes relative to :host.
-     Read more about stacking context here:
-     https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/The_stacking_context*/
-  -webkit-transform: scaleZ(1);
+  /* The no-op transform forms an independent stacking context. */
+  -webkit-transform: translateX(0);
 }
 
 :host([handle]:host) {


### PR DESCRIPTION
@dinhviethoa

You were right, -webkit-transform:scaleZ(1) was for some reason butchering font smoothing, at least on Mac. -webkit-transform:translateX(0) achieves the same effect in terms of forming a stacking context, but leaves fonts alone.

I've turned -webkit-font-smoothing:auto back on for the editor too.

![screen shot 2014-05-28 at 2 04 48 am](https://cloud.githubusercontent.com/assets/5606182/3102482/8595a554-e647-11e3-8ffb-9e094470ec32.png)
