### PR TITLE
Link to class name of referenced class if no default constructor exists.

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -3178,9 +3178,8 @@ class RunTestsAction extends SparkAction {
 
   void _initTestDriver() {
     if (testDriver == null) {
-      testDriver = new TestDriver(all_tests.oneTest, spark.jobManager,
+      testDriver = new TestDriver(all_tests.defineTests, spark.jobManager,
           connectToTestListener: true);
-      testDriver.runTests();
     }
   }
 }

--- a/ide/app/test/all.dart
+++ b/ide/app/test/all.dart
@@ -67,7 +67,3 @@ void defineTests() {
   // Run our benchmarks as well.
   benchmarks.defineTests();
 }
-
-void oneTest() {
-  services_test.oneTest();
-}

--- a/ide/app/test/files_mock.dart
+++ b/ide/app/test/files_mock.dart
@@ -153,6 +153,16 @@ DirectoryEntry createSampleDirectory3(String name) {
   return directory;
 }
 
+/**
+ * Create a directory with a dart file with given name and contents.
+ */
+DirectoryEntry createDirectoryWithDartFile(String name, String contents) {
+  MockFileSystem fs = new MockFileSystem();
+  DirectoryEntry directory = fs.createDirectory(name);
+  fs.createFile('${name}/web/sample.dart', contents: contents);
+  return directory;
+}
+
 Future<workspace.Project> linkSampleProject(
     DirectoryEntry dir, [workspace.Workspace ws]) {
   if (ws == null) ws = new workspace.Workspace();

--- a/ide/app/test/services_test.dart
+++ b/ide/app/test/services_test.dart
@@ -205,5 +205,18 @@ defineTests() {
         });
       });
     });
+
+    test('link to an instantiated class with no constructor', () {
+      DirectoryEntry dir = createDirectoryWithDartFile('foo3',
+          'void main() {var a = new MyClass();} class MyClass { }\n');
+      return linkSampleProject(dir, workspace).then((Project project) {
+        File file = project.getChildPath('web/sample.dart');
+        return analyzer.getDeclarationFor(file, 27)
+            .then((SourceDeclaration declaration) {
+          expect(declaration.getFile(project).name, "sample.dart");
+          expect(declaration.offset, 43);
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
Setup getDeclarationFor to go to class name of referenced class if no default constructor exists.  Added tests

Review @devoncarew @ussuri 
