### PR TITLE
causes assert to fail

### DIFF
--- a/widgets/lib/spark_dialog/spark_dialog.html
+++ b/widgets/lib/spark_dialog/spark_dialog.html
@@ -17,7 +17,8 @@
     <spark-modal id="modal" focused animation="{{animation}}">
       <spark-toolbar id="header" 
           horizontal 
-          justify="edges">
+          justify="edges"
+          spacing="small">
         <span id="title">{{title}}</span>
         <spark-button id="closingX" 
             flat


### PR DESCRIPTION
@ussuri noticed that master branch is failing on a `spark_toolbar.dart:enterView()` assert if `spacing` is not set to a default value. 
