### PR TITLE
Add diff3 library and support 

### DIFF
--- a/ide/app/lib/git/diff3.dart
+++ b/ide/app/lib/git/diff3.dart
@@ -11,9 +11,9 @@ import "package:diff/diff.dart" as diff3;
  */
 class Diff3 {
   static Diff3Result diff(String our, String base, String their) {
-    diff3.Diff3DigResult diff3DigResult = diff3.diff3_dig(our, base, their);
-    return new Diff3Result(diff3DigResult.Text.join("\n"),
-        diff3DigResult.Conflict);
+    diff3.Diff3DigResult diff3DigResult = diff3.diff3Dig(our, base, their);
+    return new Diff3Result(diff3DigResult.text.join("\n"),
+        diff3DigResult.conflict);
   }
 }
 

--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   cipher: '>=0.7.0 <0.8.0'
   compiler_unsupported: 0.7.1
   crypto: any
-  diff: '>=0.0.1 <0.1.0'
+  diff: '>=0.1.0 <0.2.0'
   intl: any
   json: any
   logging: any


### PR DESCRIPTION
@gaurave took a stab at what it would take to remove diff3.js dependency. This is what I think is the most minimum functions needed. Any current tests that would eventually go down this code path? Also this code has not been dartified, very straight port at the moment. 
