### PR TITLE
Remove <template id="editor-dialog">: no longer used

### DIFF
--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -154,46 +154,11 @@ button.ace_searchbtn_close:active {
   outline: none;
 }
 
-.editor-dialog {
-  background-color: white;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  top: 0;
-  z-index: 10;
-  opacity: 1;
-  transition: opacity 250ms;
-  text-align: center;
-}
-
-.editor-dialog .editor-dialog-message {
-  margin-top: 40px;
-  margin-bottom: 20px;
-  font-size: 20px;
-  color: #888;
-}
-
 .always-view-as-text-button {
   position: absolute;
   bottom: 20px;
   right: 20px;
   color: #ccc;
-}
-
-.editor-dialog a {
-  text-decoration: none;
-  color: #ccc;
-}
-
-.editor-dialog a:hover {
-  text-decoration: underline;
-  color: #888;
-}
-
-.editor-dialog.transition-hidden {
-  opacity: 0;
-  pointer-events: none;
 }
 
 .minimap {

--- a/ide/app/spark_polymer.html
+++ b/ide/app/spark_polymer.html
@@ -62,23 +62,6 @@
     </div>
   </template>
 
-  <!-- Template for Editor Dialog -->
-  <template id="editor-dialog" >
-    <div class="editor-dialog">
-      <div>
-        <div class="editor-dialog-message" style="">
-          <div>Spark can't show the content of files of this type.</div>
-        </div>
-        <div>
-          <button class="view-as-text-button">Edit as text</button>
-        </div>
-      </div>
-      <div class="always-view-as-text-button">
-        <a href="#">Always edit this kind of file as text</a>
-      </div>
-    </div>
-  </template>
-
   <!-- Template for Outline -->
   <template id="outline-template" >
     <div id="outline">


### PR DESCRIPTION
@dinhviethoa

I couldn't find any references to it anywhere.
