### PR TITLE
Fix Bower update getting stuck + Bower install/updage not showing "Getting packages..."

### DIFF
--- a/ide/app/lib/launch.dart
+++ b/ide/app/lib/launch.dart
@@ -523,7 +523,7 @@ class BowerPackagesServlet extends PicoServlet {
     Project project = webLaunchHandler.lastLaunchedProject;
     if (project == null) return null;
 
-    if (!bowerManager.properties.isProjectWithPackages(project)) return null;
+    if (!bowerManager.properties.isFolderWithPackages(project)) return null;
 
     String url = request.uri.path;
     File file = bowerManager.getResolverFor(project).resolveRefToFile(url);

--- a/ide/app/lib/package_mgmt/bower.dart
+++ b/ide/app/lib/package_mgmt/bower.dart
@@ -37,25 +37,26 @@ class BowerManager extends PackageManager {
   PackageResolver getResolverFor(Project project) =>
       new _BowerResolver._(project);
 
-  Future installPackages(Container container) =>
+  Future installPackages(Folder container) =>
       _installOrUpgradePackages(container.project, FetchMode.INSTALL);
 
-  Future upgradePackages(Container container) =>
+  Future upgradePackages(Folder container) =>
       _installOrUpgradePackages(container.project, FetchMode.UPGRADE);
 
   //
   // - end PackageManager abstract interface.
   //
 
-  Future _installOrUpgradePackages(Project project, FetchMode mode) {
-    final File specFile = project.getChild(properties.packageSpecFileName);
+  Future _installOrUpgradePackages(Folder container, FetchMode mode) {
+    final File specFile = container.getChild(properties.packageSpecFileName);
 
     // The client is expected to call us only when the project has bower.json.
     if (specFile == null) {
-      throw new StateError('installPackages() called, but there is no bower.json');
+      throw new StateError(
+          '${properties.packageSpecFileName} not found under ${container.name}');
     }
 
-    return project.getOrCreateFolder(properties.packagesDirName, true)
+    return container.getOrCreateFolder(properties.packagesDirName, true)
         .then((Folder packagesDir) {
       final fetcher = new BowerFetcher(
           packagesDir.entry, properties.packageSpecFileName);
@@ -64,7 +65,7 @@ class BowerManager extends PackageManager {
         _logger.severe('Error getting Bower packages', e);
         return new Future.error(e);
       }).then((_) {
-        return project.refresh();
+        return container.refresh();
       });
     });
   }

--- a/ide/app/lib/package_mgmt/package_manager.dart
+++ b/ide/app/lib/package_mgmt/package_manager.dart
@@ -12,12 +12,12 @@ import '../workspace.dart';
 // TODO(ussuri): Add comments.
 
 abstract class PackageServiceProperties {
-  bool isProjectWithPackages(Container project) =>
+  bool isFolderWithPackages(Folder project) =>
       project.getChild(packageSpecFileName) != null;
 
   bool isPackageResource(Resource resource) {
     return (resource is File && resource.name == packageSpecFileName) ||
-           (resource is Container && isProjectWithPackages(resource));
+           (resource is Folder && isFolderWithPackages(resource));
   }
 
   bool isInPackagesFolder(Resource resource) {
@@ -68,8 +68,8 @@ abstract class PackageManager {
   PackageBuilder getBuilder();
   PackageResolver getResolverFor(Project project);
 
-  Future installPackages(Container container);
-  Future upgradePackages(Container container);
+  Future installPackages(Folder container);
+  Future upgradePackages(Folder container);
 }
 
 abstract class PackageResolver {

--- a/ide/app/lib/package_mgmt/pub.dart
+++ b/ide/app/lib/package_mgmt/pub.dart
@@ -33,10 +33,10 @@ class PubManager extends PackageManager {
 
   PackageResolver getResolverFor(Project project) => new _PubResolver._(project);
 
-  Future installPackages(Container container) =>
+  Future installPackages(Folder container) =>
       _installUpgradePackages(container, 'get', false);
 
-  Future upgradePackages(Container container) =>
+  Future upgradePackages(Folder container) =>
       _installUpgradePackages(container, 'upgrade', true);
 
   //
@@ -44,7 +44,7 @@ class PubManager extends PackageManager {
   //
 
   Future _installUpgradePackages(
-      Container container, String commandName, bool isUpgrade) {
+      Folder container, String commandName, bool isUpgrade) {
     return tavern.getDependencies(container.entry, _handleLog, isUpgrade).
         whenComplete(() {
       return container.project.refresh();

--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -875,7 +875,7 @@ class Folder extends Container {
 
   //TODO(keertip): remove check for 'cache'
   bool isScmPrivate() => name == '.git' || name == '.svn'
-      || (name =='cache' && pubProperties.isProjectWithPackages(parent));
+      || (name =='cache' && pubProperties.isFolderWithPackages(parent));
 
   bool isDerived() {
     // TODO(devoncarew): 'cache' is a temporay folder - it will be removed.

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -1591,12 +1591,21 @@ abstract class PackageManagementAction
     if (context == null) {
       resource = spark.focusManager.currentResource;
     } else {
-      // TODO(ussuri): This seems like a stop-gap solution. Should we run for
-      // all elements that match?
+      // NOTE: [appliesTo] should ensure that this is the right choice.
       resource = context.first;
     }
 
-    spark.jobManager.schedule(_createJob(resource.parent));
+    // [appliesTo] delegates to [PackageServiceProperties.isPackageResource],
+    // which is expected to return true if:
+    // - the resourse is a folder that contains a package spec file: this is our
+    //   target, a "package dir" by definition.
+    // - the resource is a package spec file itself: our target is its parent,
+    //   which would fall into the case above if the user clicked on it instead.
+    if (resource is ws.File) {
+      resource = resource.parent;
+    }
+
+    spark.jobManager.schedule(_createJob(resource as ws.Folder));
   }
 
   String get category => 'application';
@@ -1618,13 +1627,13 @@ abstract class PubAction extends PackageManagementAction {
 class PubGetAction extends PubAction {
   PubGetAction(Spark spark) : super(spark, "pub-get", "Pub Get");
 
-  Job _createJob(ws.Container container) => new PubGetJob(spark, container);
+  Job _createJob(ws.Folder container) => new PubGetJob(spark, container);
 }
 
 class PubUpgradeAction extends PubAction {
   PubUpgradeAction(Spark spark) : super(spark, "pub-upgrade", "Pub Upgrade");
 
-  Job _createJob(ws.Container container) => new PubUpgradeJob(spark, container);
+  Job _createJob(ws.Folder container) => new PubUpgradeJob(spark, container);
 }
 
 abstract class BowerAction extends PackageManagementAction {
@@ -1637,13 +1646,13 @@ abstract class BowerAction extends PackageManagementAction {
 class BowerGetAction extends BowerAction {
   BowerGetAction(Spark spark) : super(spark, "bower-install", "Bower Install");
 
-  Job _createJob(ws.Project project) => new BowerGetJob(spark, project);
+  Job _createJob(ws.Folder container) => new BowerGetJob(spark, container);
 }
 
 class BowerUpgradeAction extends BowerAction {
   BowerUpgradeAction(Spark spark) : super(spark, "bower-upgrade", "Bower Update");
 
-  Job _createJob(ws.Project project) => new BowerUpgradeJob(spark, project);
+  Job _createJob(ws.Folder container) => new BowerUpgradeJob(spark, container);
 }
 
 /**
@@ -1965,12 +1974,12 @@ class NewProjectAction extends SparkActionWithDialog {
             spark._openFile(ProjectBuilder.getMainResourceFor(project));
 
             // Run Pub if the new project has a pubspec file.
-            if (spark.pubManager.properties.isProjectWithPackages(project)) {
+            if (spark.pubManager.properties.isFolderWithPackages(project)) {
               spark.jobManager.schedule(new PubGetJob(spark, project));
             }
 
             // Run Bower if the new project has a bower.json file.
-            if (spark.bowerManager.properties.isProjectWithPackages(project)) {
+            if (spark.bowerManager.properties.isFolderWithPackages(project)) {
               spark.jobManager.schedule(new BowerGetJob(spark, project));
             }
           });
@@ -2810,12 +2819,12 @@ class _GitCloneTask {
           });
 
           // Run Pub if the new project has a pubspec file.
-          if (spark.pubManager.properties.isProjectWithPackages(project)) {
+          if (spark.pubManager.properties.isFolderWithPackages(project)) {
             spark.jobManager.schedule(new PubGetJob(spark, project));
           }
 
           // Run Bower if the new project has a bower.json file.
-          if (spark.bowerManager.properties.isProjectWithPackages(project)) {
+          if (spark.bowerManager.properties.isFolderWithPackages(project)) {
             spark.jobManager.schedule(new BowerGetJob(spark, project));
           }
 
@@ -2949,12 +2958,12 @@ class _OpenFolderJob extends Job {
       });
 
       // Run Pub if the folder has a pubspec file.
-      if (spark.pubManager.properties.isProjectWithPackages(resource)) {
+      if (spark.pubManager.properties.isFolderWithPackages(resource)) {
         spark.jobManager.schedule(new PubGetJob(spark, resource));
       }
 
       // Run Bower if the folder has a bower.json file.
-      if (spark.bowerManager.properties.isProjectWithPackages(resource)) {
+      if (spark.bowerManager.properties.isFolderWithPackages(resource)) {
         spark.jobManager.schedule(new BowerGetJob(spark, resource));
       }
 
@@ -3003,29 +3012,29 @@ abstract class PackageManagementJob extends Job {
 }
 
 class PubGetJob extends PackageManagementJob {
-  PubGetJob(Spark spark, ws.Container container) :
+  PubGetJob(Spark spark, ws.Folder container) :
       super(spark, container, 'pub get');
 
   Future _run() => _spark.pubManager.installPackages(_container);
 }
 
 class PubUpgradeJob extends PackageManagementJob {
-  PubUpgradeJob(Spark spark, ws.Container container) :
+  PubUpgradeJob(Spark spark, ws.Folder container) :
       super(spark, container, 'pub upgrade');
 
   Future _run() => _spark.pubManager.upgradePackages(_container);
 }
 
 class BowerGetJob extends PackageManagementJob {
-  BowerGetJob(Spark spark, ws.Container project) :
-      super(spark, project, 'bower install');
+  BowerGetJob(Spark spark, ws.Folder container) :
+      super(spark, container, 'bower install');
 
   Future _run() => _spark.bowerManager.installPackages(_container);
 }
 
 class BowerUpgradeJob extends PackageManagementJob {
-  BowerUpgradeJob(Spark spark, ws.Container project) :
-      super(spark, project, 'bower upgrade');
+  BowerUpgradeJob(Spark spark, ws.Folder container) :
+      super(spark, container, 'bower upgrade');
 
   Future _run() => _spark.bowerManager.upgradePackages(_container);
 }

--- a/ide/app/test/pub_test.dart
+++ b/ide/app/test/pub_test.dart
@@ -38,9 +38,9 @@ defineTests() {
     });
 
     test('PubManager isPubProject', () {
-      expect(pubManager.properties.isProjectWithPackages(project), true);
+      expect(pubManager.properties.isFolderWithPackages(project), true);
       return project.getChild('pubspec.yaml').delete().then((_) {
-        expect(pubManager.properties.isProjectWithPackages(project), false);
+        expect(pubManager.properties.isFolderWithPackages(project), false);
       });
     });
 


### PR DESCRIPTION
@keertip
#1876 didn't completely upgrade Bower manager along the same lines as Pub one. It was thinking it was operating on a `Project`, while in fact it was a `Folder`. That caused an exception in 'Bower update', making it appear stuck.

I believe that somehow prevented the "Getting packages..." progress message from being displayed for Bower commands.

This CL:
- Moves both package managers, their abstract parent, and related commands in `Spark` to operate in terms of `Folder`, from a mix of `Container` (new after #1876) and `Project` (vestiges from before): `Folder` is what they will always get by design (`Project` is a subclass of `Folder`).
- Fixes #2263, which I've just filed for documentation purposes.
- Fixes #2118 and #2257
