### PR TITLE
Change 'Run Application' -> 'Run' and 'Open Folder' -> 'Import Folder'

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -1991,7 +1991,7 @@ class NewProjectAction extends SparkActionWithDialog {
 }
 
 class FolderOpenAction extends SparkAction {
-  FolderOpenAction(Spark spark) : super(spark, "folder-open", "Import Folder…");
+  FolderOpenAction(Spark spark) : super(spark, "folder-open", "Add Folder to Workspace…");
 
   void _invoke([Object context]) {
     spark.openFolder();
@@ -3372,7 +3372,7 @@ class ImportFileAction extends SparkAction implements ContextAction {
 }
 
 class ImportFolderAction extends SparkAction implements ContextAction {
-  ImportFolderAction(Spark spark) : super(spark, "folder-import", "Import Folder…");
+  ImportFolderAction(Spark spark) : super(spark, "folder-import", "Add Folder to Workspace…");
 
   void _invoke([List<ws.Resource> resources]) {
     spark.importFolder(resources);

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -68,7 +68,7 @@
 
             <spark-menu-item action-id="file-open" label="Open File...">
             </spark-menu-item>
-            <spark-menu-item action-id="folder-open" label="Import Folder...">
+            <spark-menu-item action-id="folder-open" label="Add Folder to Workspace...">
             </spark-menu-item>
             <spark-menu-item action-id="git-clone" label="Git Clone...">
             </spark-menu-item>


### PR DESCRIPTION
@devoncarew

Re 'Run Application': given Spark's current capabilities, it's a misnomer in many situations, e.g. when the item being "run" is a Polymer element's demo, or just a single HTML file in the hierarchy of an app, etc.
