### PR TITLE
Disabled buttons in dart2js version too

### DIFF
--- a/widgets/lib/spark_dialog_button/spark_dialog_button.dart
+++ b/widgets/lib/spark_dialog_button/spark_dialog_button.dart
@@ -35,6 +35,7 @@ class SparkDialogButton extends SparkWidget {
     setAttr('overlayToggle', submit || dismiss || cancel);
   }
 
+  // TODO(ussuri): BUG #2252
   @override
   void deliverChanges() {
     super.deliverChanges();


### PR DESCRIPTION
Fixed disabled buttons in dialogs in the dart2js version

Fixed #2350

review: @ussuri
