### PR TITLE
fix a dialog title issue

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -630,8 +630,7 @@ abstract class Spark
   }
 
   void _setErrorDialogText(String title, String message) {
-    // TODO(ussuri): Replace with ...title = title once BUG #2252 is resolved.
-    _errorDialog.dialog.setAttr('title', true, title);
+    _errorDialog.dialog.title = title;
 
     Element container = _errorDialog.getElement('#errorMessage');
     container.children.clear();
@@ -703,8 +702,7 @@ abstract class Spark
       });
     }
 
-    // TODO(ussuri): Replace with ...title = title once BUG #2252 is resolved.
-    _okCancelDialog.dialog.setAttr('title', true, title);
+    _okCancelDialog.dialog.title = title;
 
     Element container = _okCancelDialog.getElement('#okCancelMessage');
     container.children.clear();

--- a/widgets/lib/spark_dialog/spark_dialog.dart
+++ b/widgets/lib/spark_dialog/spark_dialog.dart
@@ -4,6 +4,8 @@
 
 library spark_widgets.dialog;
 
+import 'dart:html';
+
 import 'package:polymer/polymer.dart';
 
 import '../spark_modal/spark_modal.dart';
@@ -11,10 +13,15 @@ import '../common/spark_widget.dart';
 
 @CustomTag('spark-dialog')
 class SparkDialog extends SparkWidget {
+  // TODO(ussuri): Replace with a regular published property (BUG #2252).
   /**
    * The title of the dialog.
    */
-  @published String title = '';
+  @published String get title => _title;
+  @published set title(String value) {
+    _title = value;
+    if (_titleElement != null) _titleElement.text = value;
+  }
 
   /**
    * The kind of animation that the overlay should perform on open/close.
@@ -24,6 +31,8 @@ class SparkDialog extends SparkWidget {
   bool _activityVisible = false;
 
   SparkModal _modal;
+  String _title = '';
+  Element _titleElement;
 
   SparkDialog.created() : super.created();
 
@@ -32,6 +41,10 @@ class SparkDialog extends SparkWidget {
     super.enteredView();
 
     _modal = $['modal'];
+
+    _titleElement = $['title'];
+    title = _title;
+
     $['progress'].classes.toggle('hidden', !_activityVisible);
     SparkWidget.enableKeyboardEvents(_modal);
   }


### PR DESCRIPTION
@ussuri, fix an issue where some dialog titles would not show up in the deployed version of Spark. Specifically, I saw this in the error dialog titles (`spark.showErrorMessage()`) when testing the dart2js compiled version of the app. This fix works in both Dartium and dart2js.
