### PR TITLE
Reset fields of gitAuthDialog

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -3521,6 +3521,8 @@ class GitAuthenticationDialog extends SparkActionWithDialog {
       : super(spark, "git-authentication", "Authenticate", dialogElement);
 
   void _invoke([Object context]) {
+    (getElement('#gitUsername') as InputElement).value = '';
+    (getElement('#gitPassword') as InputElement).value = '';
     spark.setGitSettingsResetDoneVisible(false);
     _show();
   }


### PR DESCRIPTION
1) A cancel event is already added in the `SparkActionWithDialog` ctr. Remove duplication addition of event which was causing null completer error.
2) Reset `GitAuthDialog` fields on relaunch.

Fixes #1080 

@dinhviethoa PTAL thanks.
