### PR TITLE
Hide unexpected errors from users.

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -616,7 +616,7 @@ abstract class Spark
   /**
    * Show a model error dialog.
    */
-  void showErrorMessage(String title, String message) {
+  void showErrorMessage(String title, String message, [bool isKnownError = true]) {
     // TODO(ussuri): Polymerize.
     if (_errorDialog == null) {
       _errorDialog = createDialog(getDialogElement('#errorDialog'));
@@ -624,6 +624,11 @@ abstract class Spark
       _errorDialog.getShadowDomElement("#closingX").onClick.listen(_hideBackdropOnClick);
     }
 
+    if (!isKnownError && !SparkFlags.developerMode) {
+      // Hide unexpected errors from users. Log them in console instead.
+      window.console.log('[ERROR} ${title} : ${message}');
+      message = "Unexpected Error.";
+    }
     _setErrorDialogText(title, message);
 
     _errorDialog.show();


### PR DESCRIPTION
1) Hide unexpected errors from users.
2) Logs the errors on console instead.
3) The errors are not hidden if developer mode is on.
(#2352)

@devoncarew 
