### PR TITLE
removed the open file dialog

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -412,7 +412,8 @@ abstract class Spark
 
     actionManager.registerAction(new NextMarkerAction(this));
     actionManager.registerAction(new PrevMarkerAction(this));
-    actionManager.registerAction(new FileOpenAction(this));
+    // TODO(devoncarew): TODO(devoncarew): Removed as per #2348.
+    //actionManager.registerAction(new FileOpenAction(this));
     actionManager.registerAction(new FileNewAction(this, getDialogElement('#fileNewDialog')));
     actionManager.registerAction(new FolderNewAction(this, getDialogElement('#folderNewDialog')));
     actionManager.registerAction(new FolderOpenAction(this));
@@ -2317,7 +2318,7 @@ class GitCloneAction extends SparkActionWithProgressDialog {
   _GitCloneTask _cloneTask;
 
   GitCloneAction(Spark spark, Element dialog)
-      : super(spark, "git-clone", "Add Git Project…", dialog) {
+      : super(spark, "git-clone", "Git Clone…", dialog) {
     _repoUrlElement = _triggerOnReturn("#gitRepoUrl", false);
   }
 

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -63,14 +63,12 @@
 
             <spark-menu-item action-id="project-new" label="New Project...">
             </spark-menu-item>
-
-            <spark-menu-separator></spark-menu-separator>
-
-            <spark-menu-item action-id="file-open" label="Open File...">
+            <!-- TODO(devoncarew): Removed as per #2348. -->
+            <!-- spark-menu-item action-id="file-open" label="Open File...">
+            </spark-menu-item -->
+            <spark-menu-item action-id="folder-open" label="Open Folder...">
             </spark-menu-item>
-            <spark-menu-item action-id="folder-open" label="Add Folder to Workspace...">
-            </spark-menu-item>
-            <spark-menu-item action-id="git-clone" label="Add Git Project...">
+            <spark-menu-item action-id="git-clone" label="Git Clone...">
             </spark-menu-item>
 
             <spark-menu-separator></spark-menu-separator>


### PR DESCRIPTION
Temporarily remove the `Open File...` feature, as per #2348. @dinhviethoa

Also, renamed `Add Folder to Workspace` to `Open Folder...`, and `Add Git Project...` to `Git Clone...`. I think git clone is clearer to users, and open folder is shorter and matches the other menu item names better. @gaurave, @ussuri?
