### PR TITLE
Room for navigation buttons

### DIFF
--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -564,3 +564,11 @@ li.outlineItem a {
   transition: opacity 250ms;
   z-index: 100;
 }
+
+/*
+  We tweak the default behavior of tab bar to avoids an overlap with the
+  navigation buttons.
+*/
+.tabview-tabbar {
+  margin-right: 95px;
+}


### PR DESCRIPTION
Prevent navigation buttons overlap.

review: @ussuri
