### PR TITLE
Fix polymer unbind warning

### DIFF
--- a/ide/app/lib/ui/goto_line_view/goto_line_view.dart
+++ b/ide/app/lib/ui/goto_line_view/goto_line_view.dart
@@ -32,6 +32,8 @@ class GotoLineView extends SparkWidget {
    */
   bool get open => _container.classes.contains('showing');
 
+  bool get preventDispose => true;
+
   /**
    * Make the view visible.
    */


### PR DESCRIPTION
@ussuri : fixes the console warning
`[WARNING] polymer.unbind: [goto-line-view] already unbound, cannot cancel unbindAll`
