### PR TITLE
fix an issue where the deploy dialog submit was not enabled

### DIFF
--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -265,8 +265,10 @@
           <div>
             <input id="ip" type="radio" name="type" value="push-ip" autosave />
             <label for="ip">Deploy to a network host</label>
+            <!-- TODO(devoncarew): Also, support IPv6 name patterns. -->
             <input id="pushUrl" type="text" class="form-control"
                 placeholder="e.g. 192.168.1.101"
+                pattern="(\d{1,3}\.){3}\d{1,3}"
                 spellcheck="false" autosave/>
           </div>
         </form>


### PR DESCRIPTION
@ussuri

Fix an issue where the `Deploy` button in the deploy dialog was not enabled. The dialog has some fields that we validate, that are only used in some paths through the dialog.

I think we should move some or all of the validation logic out of the declarative part of the dialogs (html) and into the  procedural part (dart).
