### PR TITLE
workaround for an exception w/ tab

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -434,7 +434,8 @@ class AceManager {
     // Enable code completion.
     ace.require('ace/ext/language_tools');
     _aceEditor.setOption('enableBasicAutocompletion', true);
-    _aceEditor.setOption('enableSnippets', true);
+    // TODO(devoncarew): Disabled to workaround #2442.
+    //_aceEditor.setOption('enableSnippets', true);
 
     // Override Ace's `gotoline` command.
     var command = new ace.Command(


### PR DESCRIPTION
Hitting tab in the editor currently throws an exception. Possibly an issue with the snippits code, or a specific snippit?

https://github.com/dart-lang/spark/issues/2442

@dinhviethoa
