### PR TITLE
Add 'none' back for spark toolbar assert

### DIFF
--- a/widgets/lib/spark_toolbar/spark_toolbar.dart
+++ b/widgets/lib/spark_toolbar/spark_toolbar.dart
@@ -24,6 +24,6 @@ class SparkToolbar extends SparkWidget {
     assert(horizontal || vertical);
     assert(horizontal != vertical);
     assert(['left', 'right', 'center', 'spaced', 'edges'].contains(justify));
-    assert(['small', 'medium', 'large'].contains(spacing));
+    assert(['small', 'medium', 'large', 'none'].contains(spacing));
   }
 }


### PR DESCRIPTION
@ussuri seems 'none' is now an assertable string. 
