### PR TITLE
Make import folder synchronous.

### DIFF
--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -830,10 +830,9 @@ class Folder extends Container {
    */
   Future<File> importFileEntry(chrome.ChromeFileEntry sourceEntry) {
     return createNewFile(sourceEntry.name).then((File file) {
-      sourceEntry.readBytes().then((chrome.ArrayBuffer buffer) {
-        return file.setBytes(buffer.getBytes());
+      return sourceEntry.readBytes().then((chrome.ArrayBuffer buffer) {
+        return file.setBytes(buffer.getBytes()).then((_) => file);
       });
-      return file;
     });
   }
 


### PR DESCRIPTION
We are doing `folderCopy` in background with `importFolder` action. This caused the UI to hang if the folder was substantially big. We now show a blocking progress dialog for `importFolder`. Make the copy action blocking.

Also, bug(#2249) was reported where, git push was failing when importing big folders. This should probably fix that.

@devoncarew PTAL thanks.
