### PR TITLE
Restrict maximum width of file tree view panel to avoid clipped UI

### DIFF
--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -30,6 +30,7 @@
         splitterHandle="false"
         targetSize="{{splitViewPosition}}"
         minTargetSize="200"
+        maxTargetSize="600"
         on-update="{{onSplitterUpdate}}">
       <div beforeSplit>
         <spark-toolbar class="toolbar"


### PR DESCRIPTION
@gaurave 

Fixes #2527
