### PR TITLE
Rename Ok button to Done in about dialog.

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -3363,6 +3363,7 @@ class AboutSparkAction extends SparkActionWithDialog {
   AboutSparkAction(Spark spark, Element dialog)
       : super(spark, "help-about", "About Spark", dialog) {
     _checkbox.checked = _isTrackingPermitted;
+    _checkbox.onChange.listen((e) => _isTrackingPermitted = _checkbox.checked);
   }
 
   void _invoke([Object context]) {
@@ -3371,7 +3372,6 @@ class AboutSparkAction extends SparkActionWithDialog {
   }
 
   void _commit() {
-    _isTrackingPermitted = _checkbox.checked;
     _hide();
   }
 

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -440,7 +440,7 @@
           </label>
         </div>
       </div>
-      <spark-dialog-button submit>Ok</spark-dialog-button>
+      <spark-dialog-button submit>Done</spark-dialog-button>
     </spark-dialog>
 
     <!-- Settings dialog -->


### PR DESCRIPTION
@ussuri 

This now becomes more like a FYI dialog that the settings are enabled and gives an option to change. Do we need to show the dialog if the user closes spark without hitting `done` on first run ? (#2519)
