### PR TITLE
Optimize git add performance.

### DIFF
--- a/ide/app/lib/git/commands/add.dart
+++ b/ide/app/lib/git/commands/add.dart
@@ -27,14 +27,11 @@ class Add {
     return Status.updateAndGetStatus(options.store, entry).then(
         (FileStatus status) {
       if (status.type == FileStatusType.UNTRACKED) {
-        return FileStatus.createFromEntry(entry).then((FileStatus status) {
-          status.type = FileStatusType.MODIFIED;
-          options.store.index.updateIndexForEntry(entry, status);
-          return status;
-        });
-      } else {
-        return status;
+        status = FileStatus.createFromEntry(entry);
+        status.type = FileStatusType.MODIFIED;
+        options.store.index.updateIndexForEntry(entry, status);
       }
+      return status;
     });
   }
 

--- a/ide/app/lib/git/commands/index.dart
+++ b/ide/app/lib/git/commands/index.dart
@@ -392,20 +392,13 @@ class FileStatus {
     this.permission = Permissions.FILE_NON_EXECUTABLE;
   }
 
-  static Future<FileStatus> createFromEntry(chrome.Entry entry) {
-    return entry.getMetadata().then((chrome.Metadata data) {
-      // TODO(grv) : Check the modification time when it is available.
-      return getShaForEntry(entry, 'blob').then((String sha) {
-        FileStatus status = new FileStatus();
-        status.path = entry.fullPath;
-        status.sha = sha;
-        status.size = data.size;
-        status.modificationTime = data.modificationTime.millisecondsSinceEpoch;
-        // TODO(grv): Read real file permissions from metadata when available.
-        status.permission = Permissions.FILE_NON_EXECUTABLE;
-        return status;
-      });
-    });
+  static FileStatus createFromEntry(chrome.Entry entry) {
+    FileStatus status = new FileStatus();
+    status.path = entry.fullPath;
+    status.sha = '';
+    // TODO(grv): Read real file permissions from metadata when available.
+    status.permission = Permissions.FILE_NON_EXECUTABLE;
+    return status;
   }
 
   static FileStatus createForDirectory(chrome.Entry entry) {


### PR DESCRIPTION
Don't calculate sha values on git add, but delay them until the file is committed. This will not affect `git status` as the `headSha` of the added file is `null` which will always differ from the `currentSha`. Morever, it will automatically get updated on next index update. Also we always update the index before a commit.

This fixes significant performance issue specially on chromeOs.

@devoncarew PTAL thanks.
