### PR TITLE
workaround an scm exception

### DIFF
--- a/ide/app/lib/git/commands/index.dart
+++ b/ide/app/lib/git/commands/index.dart
@@ -68,7 +68,6 @@ class Index {
   }
 
   void updateIndexForFile(FileStatus status) {
-
     FileStatus oldStatus = _statusIdx[status.path];
 
     if (oldStatus != null) {
@@ -94,6 +93,8 @@ class Index {
             }
             break;
           case FileStatusType.UNTRACKED:
+            status.type = FileStatusType.UNTRACKED;
+            break;
           default:
             throw new GitException(GitErrorConstants.GIT_FILE_STATUS_TYPE_UNKNOWN,
                 "Unknown file status type: ${oldStatus.type}");
@@ -102,6 +103,7 @@ class Index {
         status.type = oldStatus.type;
       }
     }
+
     _statusIdx[status.path] = status;
     _scheduleWriteIndex();
   }


### PR DESCRIPTION
@gaurave, this isn't necessarily intended to land. I see an exception consistently with `pubspec.lock` files, even with your latest changes. This PR works around the issue, but I don't know of the implications this would have for the index state.
