### PR TITLE
focus any focusable fields when opening a dialog

### DIFF
--- a/widgets/lib/spark_dialog/spark_dialog.dart
+++ b/widgets/lib/spark_dialog/spark_dialog.dart
@@ -67,6 +67,8 @@ class SparkDialog extends SparkWidget {
           SparkWidget.inlineNestedContentNodes($['bodyContent']));
       _updateFormValidity();
       _modal.toggle();
+
+      focus();
     }
   }
 


### PR DESCRIPTION
@ussuri, fixes #2206. This manually focuses a `[focused]` field in a dialog when the dialog is opened. Fixes the focused issue for the new file dialog, new folder, project, ...
