### PR TITLE
an id changed; deploy dialog broke

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -2214,7 +2214,7 @@ class DeployToMobileAction extends SparkActionWithProgressDialog implements Cont
 
     _monitor = new ProgressMonitorImpl(this);
 
-    String type = getElement('input[name="type"]:checked').id;
+    String type = getElement('input[name="mobileDeployType"]:checked').id;
     bool useAdb = type == 'adb';
     String url = _pushUrlElement.value;
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/spark/issues/2563; deploy dialog couldn't deploy (we had an NPE when trying to retrieve the dialog checkboxes). @dinhviethoa
