### PR TITLE
consume a click event so the dialog doesn't auto close

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -1194,12 +1194,20 @@ abstract class SparkActionWithDialog extends SparkAction {
 
     final Element submitBtn = _dialog.getElement("[submit]");
     if (submitBtn != null) {
-      submitBtn.onClick.listen((_) => _commit());
+      submitBtn.onClick.listen((e) {
+        // Consume the event so that the overlayToggle doesn't close the dialog.
+        e..stopPropagation()..preventDefault();
+        _commit();
+      });
     }
 
     final Element cancelBtn = _dialog.getElement("[cancel]");
     if (cancelBtn != null) {
-      cancelBtn.onClick.listen((_) => _cancel());
+      cancelBtn.onClick.listen((e) {
+        // Consume the event so that the overlayToggle doesn't close the dialog.
+        e..stopPropagation()..preventDefault();
+        _cancel();}
+      );
     }
 
     final Element closingXBtn = _dialog.getShadowDomElement("#closingX");
@@ -2716,7 +2724,6 @@ class GitCommitAction extends SparkActionWithProgressDialog implements ContextAc
   }
 
   void _commit() {
-
     SparkDialogButton commitButton = getElement('#gitCommit');
     commitButton.disabled = true;
     commitButton.deliverChanges();


### PR DESCRIPTION
Fixes https://github.com/dart-lang/spark/issues/2579 - introduced while fixing other issues. We need to consume click events on dialog buttons so that the overlay doesn't auto-close the dialog. We want to be able to control programmatically what happens based on the specific dialog.
