### PR TITLE
Umop mobile auto launch

### DIFF
--- a/ide/app/lib/mobile/deploy.dart
+++ b/ide/app/lib/mobile/deploy.dart
@@ -117,9 +117,8 @@ class MobileDeploy {
     List<int> httpRequest = [];
 
     // Build the HTTP request headers.
-    String method = payload == null ? 'POST' : 'POST';
     String header =
-        '${method} /$path HTTP/1.1\r\n'
+        'POST /$path HTTP/1.1\r\n'
         'User-Agent: Spark IDE\r\n'
         'Host: ${target}:2424\r\n';
     List<int> body = [];


### PR DESCRIPTION
@umop, I'm able to deploy apps and have the correct app selected. I did expliment with GET vs POST - it looks like POST is the correct method. This CL mostly ignores the result of the last http call. It is http result text - the != '' check caused an error dialog to display. And we had checked mode exceptions when a non-SocketException error was thrown during deploy.
