### PR TITLE
Fix ESc issue on commit dialog.

### DIFF
--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -166,7 +166,7 @@
       <label for="renameFileName">New name</label>
       <input id="renameFileName" type="text" class="form-control"
           required pattern="[\w\.-]+"
-          spellcheck="false" autosave focused>
+          spellcheck="false" autosave>
 
       <spark-dialog-button cancel>Cancel</spark-dialog-button>
       <spark-dialog-button submit>Rename</spark-dialog-button>
@@ -177,7 +177,7 @@
       <label for="fileName">New file name</label>
       <input id="fileName" type="text" class="form-control"
           required pattern="[\w\.-]+"
-          spellcheck="false" focused>
+          spellcheck="false">
 
       <spark-dialog-button cancel>Cancel</spark-dialog-button>
       <spark-dialog-button submit>Create</spark-dialog-button>
@@ -188,7 +188,7 @@
       <label for="folderName">New folder name</label>
       <input id="folderName" type="text" class="form-control"
           required pattern="[\w\.-]+"
-          spellcheck="false" focused>
+          spellcheck="false">
 
       <spark-dialog-button cancel>Cancel</spark-dialog-button>
       <spark-dialog-button submit>Create</spark-dialog-button>


### PR DESCRIPTION
Commit dialog is fixed by focusing the right field.

The `New file`, `New Folder` and `Rename` dialog gets fixed by removing `focused` attribute. Investigating why focused field breaks the escape in these dialogs.
@ussuri 
