### PR TITLE
[Hot fix] Add header styles to chrome-apps template.

### DIFF
--- a/ide/app/lib/templates/chrome/chrome_app_js/styles.css_
+++ b/ide/app/lib/templates/chrome/chrome_app_js/styles.css_
@@ -4,3 +4,7 @@ body {
   font-size: 14px;
   margin: 15px;
 }
+
+h1, p {
+ color: #777;
+}


### PR DESCRIPTION
App harness has a bug where the `background-color` override is not working. This is a turn around to change the text color so that sample `javascript chrome app` is visible on mobile.
