### PR TITLE
Fix build not returning when cloning a dart repo.

### DIFF
--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -3105,6 +3105,8 @@ class _GitCloneTask {
 
           // Run Pub if the new project has a pubspec file.
           if (spark.pubManager.properties.isFolderWithPackages(project)) {
+            // There is issue with workspace sending duplicate events.
+            // TODO(grv): revisit workspace events.
             Timer.run(() {
               spark.jobManager.schedule(new PubGetJob(spark, project));
             });


### PR DESCRIPTION
Temporary fix to #2602 

The analyzer runs into an infinite loop when a dart repository is cloned and `pub get` is run automatically. The build is triggered twice and I suspect that few of the `workspace.ADD` events are passed twice making the analyzer run into a loop.

This temporary fixed the issue for me. We need to revisit `workspace` events and the `analyzer`.
