### PR TITLE
Added 'Segoe UI' to top of font stack to mitigate Roboto rendered badly on Windows

### DIFF
--- a/ide/app/lib/ui/goto_line_view/goto_line_view.css
+++ b/ide/app/lib/ui/goto_line_view/goto_line_view.css
@@ -33,7 +33,8 @@
   margin: 0 0 0 4px;
   height: 22px;
   /* Override Ace's inherited font */
-  font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  /* BUG #2629 */
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 500;
   font-size: 12px;
 }

--- a/ide/app/spark_common.css
+++ b/ide/app/spark_common.css
@@ -7,7 +7,8 @@
 @import url("third_party/roboto/roboto.css");
 
 body {
-  font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  /* BUG #2629 */
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 400;
   font-size: 13px;
   -webkit-font-smoothing: auto;

--- a/ide/app/spark_polymer.css
+++ b/ide/app/spark_polymer.css
@@ -112,7 +112,8 @@ div.ace_search {
   padding-right: 4px;
   width: 305px;
   /* Can't use 'inherit' here: Ace overrides that. */
-  font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  /* BUG #2629 */
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 500;
   font-size: 12px;
 }

--- a/widgets/lib/common/spark_widget.css
+++ b/widgets/lib/common/spark_widget.css
@@ -21,7 +21,8 @@
 
 /* TODO(ussuri): Add ::content here? Could be too agressive/limiting. */
 :host * {
-  font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  /* BUG #2629 */
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 400;
   font-size: 13px;
   -webkit-font-smoothing: auto;


### PR DESCRIPTION
@cleercode

Temporary solution for #2517. The tacking bug to revert once unnecessary is #2629.
