### PR TITLE
Fixed NPE in Outline

### DIFF
--- a/ide/app/lib/outline.dart
+++ b/ide/app/lib/outline.dart
@@ -46,7 +46,7 @@ class _ScrollDirection extends Enum<html.ScrollAlignment> {
 class Outline {
   List<OutlineItem> _outlineItems;
   OutlineItem _selectedItem;
-  OffsetRange _lastScrolledOffsetRange;
+  OffsetRange _lastScrolledOffsetRange = new OffsetRange();
 
   html.Element _container;
   html.DivElement _outlineDiv;
@@ -114,9 +114,7 @@ class Outline {
       _create(data);
     }
 
-    if (_lastScrolledOffsetRange != null) {
-      scrollOffsetRangeIntoView(_lastScrolledOffsetRange, _ScrollDirection.DOWN);
-    }
+    scrollOffsetRangeIntoView(_lastScrolledOffsetRange, _ScrollDirection.DOWN);
   }
 
   OutlineTopLevelItem _create(services.OutlineTopLevelEntry data) {


### PR DESCRIPTION
TBR @umop

On rare occasions, Ace was triggering the sequence `scrollOffsetRangeIntoView` ->  `offsetRange.centeredLower(_lastScrolledOffsetRange)` while `_lastScrolledOffsetRange` was still uninitialized. I'll file an issue for what those rare occasions are, but this induced problem needed to be fixed regardless.
