### PR TITLE
Fix getting packages message  minimal

### DIFF
--- a/ide/app/lib/package_mgmt/bower.dart
+++ b/ide/app/lib/package_mgmt/bower.dart
@@ -37,11 +37,11 @@ class BowerManager extends PackageManager {
   PackageResolver getResolverFor(Project project) =>
       new _BowerResolver._(project);
 
-  Future installPackages(Folder container) =>
-      _installOrUpgradePackages(container.project, FetchMode.INSTALL);
+  Future installPackages(Folder container, ProgressMonitor monitor) =>
+      _installOrUpgradePackages(container.project, FetchMode.INSTALL, monitor);
 
-  Future upgradePackages(Folder container) =>
-      _installOrUpgradePackages(container.project, FetchMode.UPGRADE);
+  Future upgradePackages(Folder container, ProgressMonitor monitor) =>
+      _installOrUpgradePackages(container.project, FetchMode.UPGRADE, monitor);
 
   // TODO(keertip): implement for bower
   Future<dynamic> arePackagesInstalled(Folder container) => new Future.value(true);
@@ -50,7 +50,8 @@ class BowerManager extends PackageManager {
   // - end PackageManager abstract interface.
   //
 
-  Future _installOrUpgradePackages(Folder container, FetchMode mode) {
+  Future _installOrUpgradePackages(
+      Folder container, FetchMode mode, ProgressMonitor monitor) {
     final File specFile = container.getChild(properties.packageSpecFileName);
 
     // The client is expected to call us only when the project has bower.json.
@@ -62,7 +63,7 @@ class BowerManager extends PackageManager {
     return container.getOrCreateFolder(properties.packagesDirName, true)
         .then((Folder packagesDir) {
       final fetcher = new BowerFetcher(
-          packagesDir.entry, properties.packageSpecFileName);
+          packagesDir.entry, properties.packageSpecFileName, monitor);
 
       return fetcher.fetchDependencies(specFile.entry, mode).catchError((e) {
         _logger.severe('Error getting Bower packages', e);

--- a/ide/app/lib/package_mgmt/package_manager.dart
+++ b/ide/app/lib/package_mgmt/package_manager.dart
@@ -6,6 +6,7 @@ library spark.package_mgmt;
 
 import 'dart:async';
 
+import '../jobs.dart';
 import '../builder.dart';
 import '../workspace.dart';
 
@@ -68,8 +69,8 @@ abstract class PackageManager {
   PackageBuilder getBuilder();
   PackageResolver getResolverFor(Project project);
 
-  Future installPackages(Folder container);
-  Future upgradePackages(Folder container);
+  Future installPackages(Folder container, ProgressMonitor monitor);
+  Future upgradePackages(Folder container, ProgressMonitor monitor);
 
   /**
    * Return `true` or `null` if all packages are installed. Otherwise, return a

--- a/ide/app/lib/package_mgmt/pub.dart
+++ b/ide/app/lib/package_mgmt/pub.dart
@@ -44,10 +44,10 @@ class PubManager extends PackageManager {
 
   PackageResolver getResolverFor(Project project) => new _PubResolver._(project);
 
-  Future installPackages(Folder container) =>
+  Future installPackages(Folder container, ProgressMonitor monitor) =>
       _installUpgradePackages(container, 'get', false);
 
-  Future upgradePackages(Folder container) =>
+  Future upgradePackages(Folder container, ProgressMonitor monitor) =>
       _installUpgradePackages(container, 'upgrade', true);
 
   Future<dynamic> arePackagesInstalled(Folder container) {

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -3358,42 +3358,46 @@ abstract class PackageManagementJob extends Job {
   Future run(ProgressMonitor monitor) {
     monitor.start(name, 1);
 
-    return _run().then((_) {
+    return _run(monitor).then((_) {
       _spark.showSuccessMessage("Successfully ran $_commandName");
     }).catchError((e) {
       _spark.showErrorMessage("Error while running $_commandName", exception: e);
     });
   }
 
-  Future _run();
+  Future _run(ProgressMonitor monitor);
 }
 
 class PubGetJob extends PackageManagementJob {
   PubGetJob(Spark spark, ws.Folder container) :
       super(spark, container, 'pub get');
 
-  Future _run() => _spark.pubManager.installPackages(_container);
+  Future _run(ProgressMonitor monitor) =>
+      _spark.pubManager.installPackages(_container, monitor);
 }
 
 class PubUpgradeJob extends PackageManagementJob {
   PubUpgradeJob(Spark spark, ws.Folder container) :
       super(spark, container, 'pub upgrade');
 
-  Future _run() => _spark.pubManager.upgradePackages(_container);
+  Future _run(ProgressMonitor monitor) =>
+      _spark.pubManager.upgradePackages(_container, monitor);
 }
 
 class BowerGetJob extends PackageManagementJob {
   BowerGetJob(Spark spark, ws.Folder container) :
       super(spark, container, 'bower install');
 
-  Future _run() => _spark.bowerManager.installPackages(_container);
+  Future _run(ProgressMonitor monitor) =>
+      _spark.bowerManager.installPackages(_container, monitor);
 }
 
 class BowerUpgradeJob extends PackageManagementJob {
   BowerUpgradeJob(Spark spark, ws.Folder container) :
       super(spark, container, 'bower upgrade');
 
-  Future _run() => _spark.bowerManager.upgradePackages(_container);
+  Future _run(ProgressMonitor monitor) =>
+      _spark.bowerManager.upgradePackages(_container, monitor);
 }
 
 class CompileDartJob extends Job {

--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -228,12 +228,12 @@ class SparkPolymer extends Spark {
 
     // Listen for job manager events.
     jobManager.onChange.listen((JobManagerEvent event) {
-      if (event.started) {
-        statusComponent.spinning = true;
-        statusComponent.progressMessage = event.job.name;
-      } else if (event.finished) {
+      if (event.finished) {
         statusComponent.spinning = false;
         statusComponent.progressMessage = null;
+      } else {
+        statusComponent.spinning = true;
+        statusComponent.progressMessage = event.toString();
       }
     });
   }


### PR DESCRIPTION
@dinhviethoa

Fixes #2293 in a minimal way. See the cause of the problem over there. 

The gist of this change:
1. Plumb the `ProgressMonitor` created in spark.dart down to `BowerFetcher` (that required trivial, mostly no-op changes in the API signatures of several package management-related classes as well). That's 90% of the changes.
2. After each Bower dependency gets downloaded, refresh the `ProgressMonitor` with the work just done. That redisplays the progress indicator with the updated value, so it stays or returns to the screen regardless of other jobs that may run in parallel and hijack the indicator.
3. Also fix `jobManager.onChange.listen` in spark_polymer.dart so that it displays intermediate progress messages from jobs, not just "started" and "finished" messages.
