### PR TITLE
Fix race condition that made it possible for N jobs to start simultaneously

### DIFF
--- a/ide/app/lib/jobs.dart
+++ b/ide/app/lib/jobs.dart
@@ -32,7 +32,7 @@ class JobManager {
     _waitingJobs.add(job);
 
     if (!isJobRunning) {
-      _scheduleNextJob();
+      _runNextJob();
     }
     return completer.future;
   }
@@ -47,15 +47,10 @@ class JobManager {
    */
   Stream<JobManagerEvent> get onChange => _controller.stream;
 
-  void _scheduleNextJob() {
-    if (!_waitingJobs.isEmpty) {
-      Job job = _waitingJobs.removeAt(0);
-      _runNextJob(job);
-    }
-  }
+  void _runNextJob() {
+    if (_waitingJobs.isEmpty) return;
 
-  void _runNextJob(Job job) {
-    _runningJob = job;
+    _runningJob = _waitingJobs.removeAt(0);
 
     Timer.run(() {
       _ProgressMonitorImpl monitor = new _ProgressMonitorImpl(this, _runningJob);
@@ -68,12 +63,12 @@ class JobManager {
           _jobFinished(_runningJob);
           if (_runningJob != null) _runningJob.done();
           _runningJob = null;
-          _scheduleNextJob();
+          _runNextJob();
         });
       } catch (e, st) {
         _logger.severe('Error running job ${_runningJob}', e, st);
         _runningJob = null;
-        _scheduleNextJob();
+        _runNextJob();
       }
     });
   }


### PR DESCRIPTION
@devoncarew
cc @dinhviethoa

This also fixes #2293, the sporadically disappearing "Getting packages..." message upon creation of a new project with some Bower or Pub packages (more pronounced for Bower, because project templates that have Pub dependencies have very few of them).

A candidate to be merged into 0.13.

The bug was that the `_runningJob` "mutex" was set in an asynchronously run `_runNextJob`. So while one job was still getting launched, another job could come, observe the mutex seemingly unlocked, and also start launching.
