### PR TITLE
Adding prepareForLinking to mock to remove warning.

### DIFF
--- a/ide/app/test/ace_test.dart
+++ b/ide/app/test/ace_test.dart
@@ -65,6 +65,7 @@ class MockAceManager implements AceManager {
   Stream get onGotoDeclaration => null;
   NavigationLocation get navigationLocation => null;
   void setupOutline(Element parentElement) { }
+  Future prepareForLinking(workspace.Project project) => new Future.value();
 }
 
 class MockAceEditor implements TextEditor {


### PR DESCRIPTION
TBR

@devoncarew 

Fixes warning in source.
