### PR TITLE
Fixed deployed version with polymer 0.11.0 + got `grind deploy` to 0 diagnostics

### DIFF
--- a/ide/app/spark_bootstrap.dart
+++ b/ide/app/spark_bootstrap.dart
@@ -26,16 +26,11 @@ import 'package:spark_widgets/spark_split_view/spark_split_view.dart';
 import 'package:spark_widgets/spark_status/spark_status.dart';
 import 'package:spark_widgets/spark_toolbar/spark_toolbar.dart';
 
-import 'lib/utils.dart';
 import 'lib/ui/commit_message_view/commit_message_view.dart';
 import 'lib/ui/goto_line_view/goto_line_view.dart';
 import 'spark_polymer_ui.dart';
-import 'spark_polymer.dart' as spark_polymer;
 
-void main() {
-  // Only execute this script if we are not running in a deployed context.
-  if (isDart2js()) return;
-
+void registerWidgetsWithPolymer() {
   // Init Polymer.
   startPolymer([], false);
 
@@ -60,7 +55,4 @@ void main() {
   Polymer.register('commit-message-view', CommitMessageView);
   Polymer.register('goto-line-view', GotoLineView);
   Polymer.register('spark-polymer-ui', SparkPolymerUI);
-
-  // Invoke Spark's main method.
-  spark_polymer.main();
 }

--- a/ide/app/spark_polymer.dart
+++ b/ide/app/spark_polymer.dart
@@ -13,6 +13,7 @@ import 'package:spark_widgets/spark_button/spark_button.dart';
 import 'package:spark_widgets/spark_dialog/spark_dialog.dart';
 
 import 'spark.dart';
+import 'spark_bootstrap.dart';
 import 'spark_flags.dart';
 import 'spark_polymer_ui.dart';
 import 'lib/actions.dart';
@@ -50,6 +51,8 @@ final _logger = new _TimeLogger();
 
 @polymer.initMethod
 void main() {
+  registerWidgetsWithPolymer();
+
   // app.json stores global per-app flags and is overwritten by the build
   // process (`grind deploy`).
   // user.json can be manually added to override some of the flags from app.json

--- a/ide/app/spark_polymer.html
+++ b/ide/app/spark_polymer.html
@@ -20,9 +20,6 @@
   <link rel="import" href="packages/spark_widgets/spark_splitter/spark_splitter.html">
   <link rel="import" href="packages/spark_widgets/spark_button/spark_button.html">
 
-  <!-- Start Spark in a non-deployed build (running directly from Dartium). -->
-  <script type="application/dart" src="spark_bootstrap.dart"></script>
-
   <!-- Ace includes -->
   <script src="packages/ace/src/js/ace.js"></script>
   <script src="packages/ace/src/js/ext-language_tools.js"></script>
@@ -131,9 +128,6 @@
 
   <script type="application/javascript" src="third_party/uuid.js/uuid.js"></script>
   <script type="application/javascript" src="lib/mobile/android_rsa.js"></script>
-
-  <!-- Start Spark in a non-deployed build (running direct from Dartium). -->
-  <script type="application/dart" src="spark_bootstrap.dart"></script>
 
   <!-- Start Spark in a deployed build. -->
   <script type="application/dart" src="spark_polymer.dart"></script>


### PR DESCRIPTION
TBR: @devoncarew, @financeCoding (since both of you participated in spark_bootstrap.dart, I believe).

It appears that manual registering of used Polymer element is now required in the deployed version too: otherwise, the elements do not upgrade.

Fixes #2695
