### PR TITLE
Fix: programmatic changes to spark-dialog's `animation` weren't seen in spark-overlay's CSS

### DIFF
--- a/widgets/lib/spark_dialog/spark_dialog.html
+++ b/widgets/lib/spark_dialog/spark_dialog.html
@@ -14,10 +14,7 @@
   <template>
     <link rel="stylesheet" href="spark_dialog.css">
 
-    <!-- TODO(ussuri): should be `animation="{{animation}}", but since
-     Polymer 0.11.0 programmatically set `animation` isn't correctly seen by
-     spark-overlay's CSS; statically set `animation` is. BUG #2690 -->
-    <spark-modal id="modal" focused animation="scale-slideup">
+    <spark-modal id="modal" focused animation="{{animation}}">
       <spark-toolbar id="header"
           horizontal
           justify="edges"

--- a/widgets/lib/spark_overlay/spark_overlay.dart
+++ b/widgets/lib/spark_overlay/spark_overlay.dart
@@ -123,7 +123,7 @@ class SparkOverlay extends SparkWidget {
   /**
    * The kind of animation that the overlay should perform on open/close.
    */
-  @published String animation = 'none';
+  @PublishedProperty(reflect: true) String animation = 'none';
 
   static final List<String> _SUPPORTED_ANIMATIONS = [
     'none', 'fade', 'shake', 'scale-slideup'


### PR DESCRIPTION
TBR: @devoncarew

Fixes #2690 (discussed in detail there).
