### PR TITLE
Un-deliverChanges() #1: get rid of the toxic addEventListener()

### DIFF
--- a/widgets/lib/common/spark_widget.dart
+++ b/widgets/lib/common/spark_widget.dart
@@ -169,11 +169,11 @@ class SparkWidget extends PolymerElement {
         shadowRoot.contains(e.target);
   }
 
-  static void addEventHandlers(
-      List<StreamSubscription> eventSubs,
+  static List<StreamSubscription> addEventHandlers(
       Iterable<Stream<Event>> eventStreams,
       Function handler,
       {bool capture: false}) {
+    final List<StreamSubscription> eventSubs = [];
     eventStreams.forEach((stream) {
       if (capture) {
         eventSubs.add(stream.capture(handler));
@@ -181,6 +181,7 @@ class SparkWidget extends PolymerElement {
         eventSubs.add(stream.listen(handler));
       }
     });
+    return eventSubs;
   }
 
   static void removeEventHandlers(List<StreamSubscription> eventSubs) {

--- a/widgets/lib/spark_dialog/spark_dialog.dart
+++ b/widgets/lib/spark_dialog/spark_dialog.dart
@@ -130,15 +130,19 @@ class _ValidatedField {
     // (red border) when it's not focused. Don't show red border while editing
     // to avoid distraction.
     _removeVisited();
-    SparkWidget.addEventHandlers(
-        _eventSubs, [_element.onFocus, _element.onClick], _addVisited);
+    _eventSubs.addAll(
+        SparkWidget.addEventHandlers(
+            [_element.onFocus, _element.onClick], _addVisited));
 
     // Listen to editing-related events to update the validity. Just listening
     // to the parent form's [onChange] isn't enough to react to real-time edits.
-    SparkWidget.addEventHandlers(
-        _eventSubs,
-        [_element.onChange, _element.onInput, _element.onPaste, _element.onReset],
-        _updateValidity);
+    _eventSubs.addAll(
+        SparkWidget.addEventHandlers(
+            [_element.onChange,
+             _element.onInput,
+             _element.onPaste,
+             _element.onReset],
+            _updateValidity));
 
     // Detect programmatic changes to some attributes. Sadly, that doesn't
     // include [value], because [value] is special (not a pure attribute).

--- a/widgets/lib/spark_overlay/spark_overlay.dart
+++ b/widgets/lib/spark_overlay/spark_overlay.dart
@@ -177,8 +177,8 @@ class SparkOverlay extends SparkWidget {
     _SparkOverlayManager.trackOverlays(this);
 
     if (opened) {
-        SparkWidget.addEventHandlers(
-            _eventSubs, [window.onResize], resizeHandler);
+      _eventSubs.addAll(
+          SparkWidget.addEventHandlers([window.onResize], resizeHandler));
 
       /**
        * For modal and auto-closing overlays, intercept and block some events
@@ -200,13 +200,14 @@ class SparkOverlay extends SparkWidget {
         }
         if (autoClose) {
           eventStreams.addAll([
-             document.body.onMouseDown,
-             document.body.onMouseWheel,
-             document.body.onContextMenu,
+              document.body.onMouseDown,
+              document.body.onMouseWheel,
+              document.body.onContextMenu,
           ]);
         }
-        SparkWidget.addEventHandlers(
-            _eventSubs, eventStreams, _captureHandler, capture: true);
+        _eventSubs.addAll(
+            SparkWidget.addEventHandlers(
+                eventStreams, _captureHandler, capture: true));
       }
     } else {
       SparkWidget.removeEventHandlers(_eventSubs);


### PR DESCRIPTION
@devoncarew

Addresses #2611.

Additional forward-looking change added @published_reflected annotation (the comment explains what it is for).

Additional changes in spark_dialog.dart to make sure duplicate event handlers are not added (that was previously guaranteed by the addEventListener W3C spec).
