### PR TITLE
upgrade polymer deps to capture a fix to a polymer expressions issue

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -24,20 +24,18 @@ dependencies:
   markdown: '>=0.7.0 <0.8.0'
   mime: any
   path: any
-  polymer: 0.11.0
+  polymer: '>=0.11.0 <0.12.0'
   spark_widgets:
     path: ../widgets
   tavern:
     git: https://github.com/tapted/tavern.git
     version: '>=0.0.5'
-  unittest: '>=0.10.0'
+  unittest: '>=0.11.0 <0.12.0'
   uuid: '>=0.3.0 <0.4.0'
-  yaml: '>=0.9.0 <0.10.0'
+  yaml: '>=1.1.0 <1.2.0'
 dev_dependencies:
   args: any
   grinder: '>=0.5.0 <0.6.0'
-dependency_overrides:
-  barback: 0.13.0
 transformers:
 - polymer:
     entry_points: web/spark_polymer.html

--- a/widgets/pubspec.yaml
+++ b/widgets/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
   bootjack: '>=0.6.5 <0.7.0'
-  polymer: 0.11.0
+  polymer: '>=0.11.0 <0.12.0'
 
 dev_dependencies:
-  unittest: '>=0.10.1+1 <0.11.0'
+  unittest: '>=0.11.0 <0.12.0'
 
 transformers:
 - polymer:


### PR DESCRIPTION
Upgrade our polymer dependencies to capture a fix to polymer expressions. Without this, the app throws 'Uncaught TypeError: undefined is not a function' at startup and doesn't finish launching.

Will TBR to unbreak the bot.

@ussuri, @dinhviethoa
