### PR TITLE
fix an issue wrt typed_data

### DIFF
--- a/ide/app/lib/utils.dart
+++ b/ide/app/lib/utils.dart
@@ -127,8 +127,14 @@ Future<List<int>> getAppContentsBinary(String path) {
   String url = chrome.runtime.getURL(path);
 
   return html.HttpRequest.request(url, responseType: 'arraybuffer').then((request) {
-    typed_data.Uint8List response = request.response;
-    return response;
+    var response = request.response;
+
+    if (response is List) {
+      return response;
+    } else {
+      typed_data.ByteBuffer buffer = request.response;
+      return new typed_data.Uint8List.view(buffer);
+    }
   });
 }
 


### PR DESCRIPTION
In Dartium, Uint8List had incorrectly implemented ByteBuffer. Some places where we were expecting ByteBuffers we were actually getting Uint8Lists; things worked correctly because of the `implements ByteBuffer`. This changed in the Dart SDK 1.6; updating our code to account for this.

@keertip
