### PR TITLE
Improved ListView performance: lazily add elements to the DOM

### DIFF
--- a/ide/app/lib/ui/widgets/listview.dart
+++ b/ide/app/lib/ui/widgets/listview.dart
@@ -164,6 +164,8 @@ class ListView {
           ..height = '${separatorHeight}px'
           ..top = '${y}px';
         y += separatorHeight;
+      } else {
+        separatorHeight = 0;
       }
 
       int cellHeight = _delegate.listViewHeightForRow(this, i);
@@ -230,16 +232,14 @@ class ListView {
     if (middle == left) {
       if (y >= _rows[right].separatorY) {
         return right;
-      }
-      else {
+      } else {
         return left;
       }
     }
 
     if (y >= _rows[middle].separatorY) {
       return _findRow(y, middle, right);
-    }
-    else {
+    } else {
       return _findRow(y, 0, middle - 1);
     }
   }

--- a/ide/app/lib/ui/widgets/listview_row.dart
+++ b/ide/app/lib/ui/widgets/listview_row.dart
@@ -17,8 +17,12 @@ import 'listview_cell.dart';
 class ListViewRow {
   ListViewCell cell;
   Element container;
+  // y is the vertical position of the row.
   int y;
+  // height is the height of the row.
   int height;
+  // separator can be null, which means that there's no separator before this
+  // row. In this case, separatorY = y and separatorHeight is 0.
   Element separator;
   int separatorY;
   int separatorHeight;


### PR DESCRIPTION
After measurements: I found out that we had a `_container.clientHeight` left, which did nothing, just computing size. It was done at every stage of the loop and was expensive overall.

Also, after removing the line describe above, in the measurement, the top expensive operation was adding items to the DOM. Then, I changed the listview to add effectively items to the DOM only when they were visible, which means that it needs to listen to the scroll events to update the DOM.

review: @devoncarew

Fixed #2737
