### PR TITLE
some error dialog styling issues

### DIFF
--- a/ide/app/lib/services/services_common.dart
+++ b/ide/app/lib/services/services_common.dart
@@ -184,7 +184,7 @@ class CompileResult {
     } else if (problems.length == 1) {
       return problems.first.toString();
     } else {
-      return '${problems}';
+      return problems.join('\n');
     }
   }
 }

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -611,6 +611,7 @@ abstract class Spark
    */
   void showErrorMessage(String title, {String message, var exception}) {
     const String UNKNOWN_ERROR_STRING = 'Unknown error.';
+
     // TODO(ussuri): Polymerize.
     if (_errorDialog == null) {
       _errorDialog = createDialog(getDialogElement('#errorDialog'));
@@ -618,21 +619,25 @@ abstract class Spark
       _errorDialog.getShadowDomElement("#closingX").onClick.listen(_hideBackdropOnClick);
     }
 
-    if (exception is SparkException) {
-        message = exception.message;
-    } else if (exception != null) {
-      if (message == null) message = '';
-      // TODO(grv): wrap all exceptions as spark exception,
-      // and show 'Unexpected error.' to the user for unknown exceptions.
-      message = message + ' : ' + exception.toString();
-      // Log the actual exception on console if running in developer mode.
-      if (SparkFlags.developerMode) {
-        window.console.log(exception);
-      }
-    } else if (message == null) {
-      message = UNKNOWN_ERROR_STRING;
+    if (exception != null && SparkFlags.developerMode) {
+      window.console.log(exception);
     }
-    _setErrorDialogText(title, message);
+
+    String text = message != null ? message + '\n' : '';
+
+    if (exception != null) {
+      if (exception is SparkException) {
+        text += exception.message;
+      } else {
+        text += '${exception}';
+      }
+    }
+
+    if (text.isEmpty) {
+      text = UNKNOWN_ERROR_STRING;
+    }
+
+    _setErrorDialogText(title, text.trim());
     _errorDialog.show();
   }
 
@@ -642,7 +647,7 @@ abstract class Spark
     Element container = _errorDialog.getElement('#errorMessage');
     container.children.clear();
     List<String> lines = message.split('\n');
-    for(String line in lines) {
+    for (String line in lines) {
       Element lineElement = new Element.p();
       lineElement.text = line;
       container.children.add(lineElement);

--- a/ide/app/spark_polymer_ui.css
+++ b/ide/app/spark_polymer_ui.css
@@ -164,6 +164,11 @@ spark-dialog {
   margin: 0 20px;
 }
 
+#errorMessage {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 #gitResetSettingsDone,
 #preferenceResetResult {
   display: none;


### PR DESCRIPTION
@gaurave, @ussuri, fixes https://github.com/dart-lang/chromedeveditor/issues/2708
- the error dialog now has a max size, and the message will scroll within that if necessary
- fixed some issues with joining the message and exception

before:
![screen shot 2014-07-01 at 4 42 54 pm](https://cloud.githubusercontent.com/assets/1269969/3450536/00422524-017e-11e4-9563-bedb92f94b9f.png)

after:
![screen shot 2014-07-01 at 5 01 23 pm](https://cloud.githubusercontent.com/assets/1269969/3450540/07f38d9e-017e-11e4-8a9f-b3e8b1159fa5.png)
