### PR TITLE
show ellipsis properly if the text overflows in root directory settings

### DIFF
--- a/ide/app/spark_polymer_ui.css
+++ b/ide/app/spark_polymer_ui.css
@@ -271,3 +271,8 @@ label[for="stripWhitespace"] {
   margin-left: 10px;
   vertical-align: middle;
 }
+
+#directoryLabel {
+  overflow: hidden;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Fixed #2496

TBR: @devoncarew
