### PR TITLE
shorten analytics exceptions

### DIFF
--- a/ide/app/lib/analytics.dart
+++ b/ide/app/lib/analytics.dart
@@ -193,7 +193,7 @@ class Tracker extends _ProxyHolder {
    */
   void sendException([String description, bool fatal]) {
     if (description != null && description.length > MAX_EXCEPTION_LENGTH) {
-      description = '${description.substring(0, MAX_EXCEPTION_LENGTH - 1)}~';
+      description = '${description.substring(0, MAX_EXCEPTION_LENGTH - 1)}-';
     }
 
     _proxy.callMethod('sendException', [description, fatal]);

--- a/ide/app/lib/utils.dart
+++ b/ide/app/lib/utils.dart
@@ -398,7 +398,7 @@ String minimizeStackTrace(StackTrace st) {
     lines = lines.sublist(index - 1);
   }
 
-  return lines.join('\n');
+  return lines.join('#');
 }
 
 // A sample stack trace from Dartium:
@@ -425,6 +425,11 @@ final RegExp DART2JS_REGEX_1 = new RegExp(r'at (\S+) \((\S+)\)');
 final RegExp DART2JS_REGEX_2 = new RegExp(r'at (\S+) (\[.+\]) \((\S+)\)');
 
 String _minimizeLine(String line) {
+  Function minimizePath = (String path) {
+    // Replace a long deployed path with a shorter equivalent.
+    return line.replaceAll('spark_polymer.html_bootstrap.dart.js', 'spark.js');
+  };
+
   // Try and match a dartium stack trace first.
   Match match = DARTIUM_REGEX.firstMatch(line);
 
@@ -432,7 +437,7 @@ String _minimizeLine(String line) {
     String method = match.group(1);
     method = method.replaceAll('<anonymous closure>', '<anon>');
     String location = _removeExtPrefix(match.group(2));
-    return '${method} ${location}';
+    return minimizePath('${method} ${location}');
   }
 
   // Try and match a dart2js stack trace.
@@ -441,7 +446,7 @@ String _minimizeLine(String line) {
   if (match != null) {
     String method = match.group(1);
     String location = _removeExtPrefix(match.group(2));
-    return '${method} ${location}';
+    return minimizePath('${method} ${location}');
   }
 
   // Try and match an alternative dart2js stack trace format.
@@ -450,7 +455,7 @@ String _minimizeLine(String line) {
   if (match != null) {
     String method = match.group(1);
     String location = _removeExtPrefix(match.group(3));
-    return '${method} ${location}';
+    return minimizePath('${method} ${location}');
   }
 
   return line;

--- a/ide/app/spark.dart
+++ b/ide/app/spark.dart
@@ -3819,7 +3819,7 @@ void _handleUncaughtException(error, [StackTrace stackTrace]) {
   // We don't log the error object itself because of PII concerns.
   final String errorDesc = error != null ? error.runtimeType.toString() : '';
   final String desc =
-      '${errorDesc}\n${utils.minimizeStackTrace(stackTrace)}'.trim();
+      '${errorDesc}|${utils.minimizeStackTrace(stackTrace)}'.trim();
 
   _analyticsTracker.sendException(desc);
 


### PR DESCRIPTION
Attempt to shorten up the captured exception stack traces. We're trying to fit an exception in the first 100 chars, and right now we're not really capturing actionable data.

@umop (TBR)
