### PR TITLE
fix builder issue with packages folder changes

### DIFF
--- a/ide/app/lib/dart/dart_builder.dart
+++ b/ide/app/lib/dart/dart_builder.dart
@@ -13,8 +13,6 @@ import '../jobs.dart';
 import '../services.dart';
 import '../workspace.dart';
 
-final _disableDartAnalyzer = false;
-
 Logger _logger = new Logger('spark.dart_builder');
 
 /**
@@ -29,8 +27,6 @@ class DartBuilder extends Builder {
   }
 
   Future build(ResourceChangeEvent event, ProgressMonitor monitor) {
-    if (_disableDartAnalyzer) return new Future.value();
-
     List<ChangeDelta> changes = event.changes.where(
         (c) => c.resource is File && _includeFile(c.resource)).toList();
     List<ChangeDelta> projectDeletes = event.changes.where(
@@ -67,11 +63,24 @@ class DartBuilder extends Builder {
         List<File> deletedFiles = changes.where(
             (c) => c.isDelete).map((c) => c.resource).toList();
 
-        _removeSecondaryPackages(addedFiles);
-        _removeSecondaryPackages(changedFiles);
-        _removeSecondaryPackages(deletedFiles);
+        bool hasNewPackageFiles = addedFiles.any(
+            (r) => analyzer.getPackageManager().properties.isInPackagesFolder(r));
 
-        return context.processChanges(addedFiles, changedFiles, deletedFiles);
+        if (hasNewPackageFiles) {
+          // We currently need to tear down the analysis context and build a
+          // new one.
+          _logger.info('packages/ changes detected; bouncing analysis context');
+
+          return analyzer.disposeProjectAnalyzer(context).then((_) {
+            return analyzer.createProjectAnalyzer(project);
+          });
+        } else {
+          _removeSecondaryPackages(addedFiles);
+          _removeSecondaryPackages(changedFiles);
+          _removeSecondaryPackages(deletedFiles);
+
+          return context.processChanges(addedFiles, changedFiles, deletedFiles);
+        }
       }
     }
   }

--- a/ide/app/spark_polymer_ui.html
+++ b/ide/app/spark_polymer_ui.html
@@ -234,17 +234,17 @@
                 Web Starter Kit
               </option>
             </optgroup>
-            <optgroup label="Chrome apps">
+            <optgroup label="Chrome Apps">
               <option value="chrome/chrome_app_dart">
-                Dart Chrome app
+                Dart Chrome App
               </option>
               <option value="chrome/chrome_app_js">
-                JavaScript Chrome app
+                JavaScript Chrome App
               </option>
               <!-- This one currently can't possibly work due to Polymer
                    JS breaking the CSP. BUG #1933. -->
               <option value="chrome/chrome_app_polymer_js;polymer,core-elements">
-                JavaScript Chrome app using Polymer
+                JavaScript Chrome App using Polymer
               </option>
               <!-- This one works when installed in Chrome manually, but
                    launching via the 'Run' button is broken. BUG #1935. -->
@@ -291,10 +291,10 @@
             </optgroup>
             <optgroup label="Chrome apps">
               <option value="chrome/chrome_app_dart">
-                Dart Chrome app
+                Dart Chrome App
               </option>
               <option value="chrome/chrome_app_js">
-                JavaScript Chrome app
+                JavaScript Chrome App
               </option>
             </optgroup>
             <optgroup label="Polymer elements">


### PR DESCRIPTION
Fix an issue where newly created dart projects would show up with analysis errors. The issue is that the dart analyzer doesn't handle refreshing itself when content changes in the packages/ folder. The dart editor works around this issue; we will as well :) There's an open issue to push the fix into the analysis engine itself.

fixes #2602, @dinhviethoa. Also, some small template tweaks.
