### PR TITLE
fix a bower regression; also, strip query params

### DIFF
--- a/ide/app/lib/launch.dart
+++ b/ide/app/lib/launch.dart
@@ -876,7 +876,7 @@ class BowerPackagesServlet extends PicoServlet {
 
     if (!bowerManager.properties.isFolderWithPackages(project)) return null;
 
-    String url = request.uri.path;
+    String url = _getPath(request);
     File file = bowerManager.getResolverFor(project).resolveRefToFile(url);
     return file;
   }
@@ -1043,14 +1043,21 @@ class Dart2JsServlet extends PicoServlet {
             '${result.output.length ~/ 1024} kb');
         HttpResponse response = new HttpResponse.ok();
         response.setContent(result.output);
-        response.setContentTypeFrom(request.uri.path);
+        response.setContentTypeFrom(_getPath(request));
         return response;
       }
     }).whenComplete(() => completer.complete());
   }
 }
 
-String _getPath(HttpRequest request) => request.uri.pathSegments.join('/');
+/**
+ * Return the [HttpRequest]'s uri with any query parameters stripped off.
+ */
+String _getPath(HttpRequest request) {
+  String path = request.uri.pathSegments.join('/');
+  int index = path.indexOf('?');
+  return index == -1 ? path : path.substring(0, index);
+}
 
 /**
  * Get user disaplyable text for the given error.

--- a/ide/app/lib/package_mgmt/bower.dart
+++ b/ide/app/lib/package_mgmt/bower.dart
@@ -103,6 +103,8 @@ class _BowerResolver extends PackageResolver {
     if (url.isEmpty) return null;
     url = url.replaceFirst(PACKAGE_REF_PREFIX_RE, '');
 
+    if (url.startsWith('/')) url = url.substring(1);
+
     return folder.getChildPath(url);
   }
 


### PR DESCRIPTION
- fix a recent regression when serving `bower_components` content; the paper polymer sample stopped working
- fix https://github.com/dart-lang/chromedeveditor/issues/2965 - can't serve content that uses a GET query param

TBR; @ussuri, @dinhviethoa
