### PR TITLE
better messaging for windows pub

### DIFF
--- a/ide/app/lib/exception.dart
+++ b/ide/app/lib/exception.dart
@@ -174,8 +174,8 @@ class SparkErrorMessages {
       " possibly an invalid repo URL?";
 
   static const String RUN_APP_NOT_FOUND_IN_CHROME_MSG =
-      "It looks like the application failed to get installed in Chrome. "
-      "Has Chrome displayed any errors?";
+      "Failed to install the application into Chrome; please check Chrome for "
+      "error messages.";
 
   static const String PUB_ON_WINDOWS_MSG =
       "Running 'pub get' and 'pub upgrade' is currently not supported on "

--- a/ide/app/lib/package_mgmt/pub.dart
+++ b/ide/app/lib/package_mgmt/pub.dart
@@ -77,8 +77,7 @@ class PubManager extends PackageManager {
   PackageResolver getResolverFor(Project project) =>
       new _PubResolver._(this, project);
 
-  // Don't run pub on Windows: https://github.com/dart-lang/chromedeveditor/issues/2743
-  bool canRunPub(Folder project) => pubProperties.isFolderWithPackages(project) && !PlatformInfo.isWin;
+  bool canRunPub(Folder project) => pubProperties.isFolderWithPackages(project);
 
   Future installPackages(Folder container, ProgressMonitor monitor) =>
       _installUpgradePackages(container, 'get', false, monitor);
@@ -113,6 +112,9 @@ class PubManager extends PackageManager {
       String commandName,
       bool isUpgrade,
       ProgressMonitor monitor) {
+    // Don't run pub on Windows (#2743).
+    if (PlatformInfo.isWin) return new Future.value();
+
     // Fake the total amount of work, since we don't know it. When an update
     // comes from Tavern, just refresh the generic message w/o showing progress.
     monitor.start(

--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -161,9 +161,10 @@ Future releaseNightly(GrinderContext context) {
 
   if (channel == null) {
     // This branch is not part of any channel.
-    context.log("Spark can't be released from here.");
-    return;
+    context.fail("Spark can't be released from here.");
+    return new Future.error("Spark can't be released from here.");
   }
+
   String appID = channelConfig['id'];
 
   // Tweak the version number in the manifest.json file using drone.io build number.


### PR DESCRIPTION
Better messaging for the pub/windows issue. This gives the user an indication that Dart projects will be broken on windows until they take action, and tells the user what action to take. fixed https://github.com/dart-lang/chromedeveditor/issues/2991
- when auto-running pub for new project creating, display a dialog telling the user they need to install the dart command-line tools and and to manually run pub
- tweak to an error message for a launch failure
- fix an analysis warning in grind.dart

@dinhviethoa, @keertip
