### PR TITLE
More informative logging for `git clone`

### DIFF
--- a/ide/app/lib/git/commands/clone.dart
+++ b/ide/app/lib/git/commands/clone.dart
@@ -55,7 +55,7 @@ class Clone {
   }
 
   Future clone() {
-    _stopwatch = new PrintProfiler('clone');
+    _stopwatch = new PrintProfiler('clone ${_options.repoUrl}');
     return _clone();
   }
 


### PR DESCRIPTION
...especially useful when mass cloning Bower packages.

TBR: @gaurave
