### PR TITLE
fix a performance issue when removing projects

### DIFF
--- a/ide/app/lib/editor_area.dart
+++ b/ide/app/lib/editor_area.dart
@@ -118,8 +118,7 @@ class EditorArea extends TabView {
 
     _workspace.onResourceChange.listen((ResourceChangeEvent event) {
       // TODO(dvh): reflect name change instead of closing the file.
-      event =
-          new ResourceChangeEvent.fromList(event.changes, filterRename: true);
+      event = new ResourceChangeEvent.fromList(event.changes, filterRename: true);
       for (ChangeDelta delta in event.changes) {
         if (delta.isDelete && delta.resource.isFile) {
           closeFile(delta.resource);
@@ -248,18 +247,18 @@ class EditorArea extends TabView {
   /// Closes the tab.
   void closeFile(File file) {
     EditorTab tab = _tabOfFile[file];
+
     if (tab != null) {
       remove(tab);
       tab.close();
       editorProvider.close(file);
       _nameController.add(selectedTab == null ? null : selectedTab.label);
+      _savePersistedTabs();
     }
-
-    _savePersistedTabs();
   }
 
-  // Replaces the file loaded in a tab with a renamed version of the file
-  // The new tab is not selected.
+  // Replaces the file loaded in a tab with a renamed version of the file. The
+  // new tab is not selected.
   void renameFile(Resource file) {
     if (_tabOfFile.containsKey(file)) {
       EditorTab tab = _tabOfFile[file];


### PR DESCRIPTION
Fix https://github.com/dart-lang/chromedeveditor/issues/3006. The EditorArea._savePersistedTabs() was being called for every deleted resource, which ends up being slow.

@dinhviethoa
