### PR TITLE
check for the availabilty of chrome apis

### DIFF
--- a/ide/app/lib/launch.dart
+++ b/ide/app/lib/launch.dart
@@ -404,6 +404,16 @@ class ChromeAppLocalLaunchHandler extends LaunchTargetHandler {
   }
 
   Future launch(Application application, LaunchTarget launchTarget) {
+    if (!management.available) {
+      return new Future.error(
+          'Unable to launch; the chrome.management API is not available.');
+    }
+
+    if (!developerPrivate.available) {
+      return new Future.error(
+          'Unable to launch; the chrome.developerPrivate API is not available.');
+    }
+
     Container container = application.primaryResource;
 
     String idToLaunch;


### PR DESCRIPTION
Add an error message when trying to run a chrome app and the management APIs are not available. Address part of issue https://github.com/dart-lang/chromedeveditor/issues/2993. TBR. @gaurave
