### PR TITLE
quiet a bower warning

### DIFF
--- a/ide/app/lib/package_mgmt/bower_fetcher.dart
+++ b/ide/app/lib/package_mgmt/bower_fetcher.dart
@@ -122,6 +122,8 @@ class BowerFetcher {
   }
 
   List<_Package> _parseDepsFromSpec(String spec) {
+    if (spec.isEmpty) spec = '{}';
+
     Map<String, dynamic> specMap;
     try {
       specMap = JSON.decode(spec);

--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -20,7 +20,6 @@ import 'builder.dart';
 import 'enum.dart';
 import 'exception.dart';
 import 'jobs.dart';
-import 'package_mgmt/pub.dart';
 import 'preferences.dart';
 import 'utils.dart';
 


### PR DESCRIPTION
@ussuri, a missing bower.json file in a remote repo would cause a warning in the log - this quiets that warning.
