### PR TITLE
address a few analysis warnings

### DIFF
--- a/ide/app/lib/git/commands/pull.dart
+++ b/ide/app/lib/git/commands/pull.dart
@@ -14,10 +14,7 @@ import '../objectstore.dart';
 import '../options.dart';
 import '../utils.dart';
 import 'checkout.dart';
-import 'commit.dart';
-import 'constants.dart';
 import 'fetch.dart';
-import 'merge.dart';
 
 /**
  * A git pull command implmentation.
@@ -91,25 +88,26 @@ class Pull {
   Future _nonFastForwardPull(String localSha, String commonSha, String remoteSha) {
     // TODO(grv): Support non-fast-foward pulls.
     return new Future.error(new GitException(GitErrorConstants.GIT_PULL_NON_FAST_FORWARD));
-    var shas = [localSha, commonSha, remoteSha];
-    return store.getHeadRef().then((String headRefName) {
-      return store.getTreesFromCommits(shas).then((trees) {
-        return Merge.mergeTrees(store, trees[0], trees[1], trees[2])
-            .then((String finalTreeSha) {
-          return store.getCurrentBranch().then((branch) {
-            options.branchName = branch;
-            options.commitMessage = MERGE_BRANCH_COMMIT_MSG + options.branchName;
-            // Create a merge commit by default.
-            return Commit.createCommit(options, localSha, finalTreeSha,
-                headRefName).then((commitSha) {
-              return Checkout.checkout(options, commitSha);
-            });
-          });
-        }).catchError((e) {
-          return new Future.error(
-              new GitException(GitErrorConstants.GIT_MERGE_ERROR));
-        });
-      });
-    });
+
+//    List shas = [localSha, commonSha, remoteSha];
+//    return store.getHeadRef().then((String headRefName) {
+//      return store.getTreesFromCommits(shas).then((trees) {
+//        return Merge.mergeTrees(store, trees[0], trees[1], trees[2])
+//            .then((String finalTreeSha) {
+//          return store.getCurrentBranch().then((branch) {
+//            options.branchName = branch;
+//            options.commitMessage = MERGE_BRANCH_COMMIT_MSG + options.branchName;
+//            // Create a merge commit by default.
+//            return Commit.createCommit(options, localSha, finalTreeSha,
+//                headRefName).then((commitSha) {
+//              return Checkout.checkout(options, commitSha);
+//            });
+//          });
+//        }).catchError((e) {
+//          return new Future.error(
+//              new GitException(GitErrorConstants.GIT_MERGE_ERROR));
+//        });
+//      });
+//    });
   }
 }

--- a/ide/app/lib/workspace.dart
+++ b/ide/app/lib/workspace.dart
@@ -313,6 +313,10 @@ class Workspace extends Container {
     return _store.setValue('workspaceRoots', JSON.encode(data));
   }
 
+  Future<File> getOrCreateFile(String name, [bool createIfMissing = false]) {
+    return new Future.error('getOrCreateFile() not valid for the Workspace');
+  }
+
   bool get syncFsIsAvailable => _syncFileSystem != null;
 
   // List of files modified by the server.
@@ -591,6 +595,11 @@ abstract class Container extends Resource {
 
     return severity;
   }
+
+  /**
+   * Gets an existing [File] (or creates a new one) with the given name.
+   */
+  Future<File> getOrCreateFile(String name, [bool createIfMissing = false]);
 }
 
 abstract class Resource {
@@ -826,9 +835,6 @@ class Folder extends Container {
     });
   }
 
-  /**
-   * Gets an existing or creates a new [File] with the given name.
-   */
   Future<File> getOrCreateFile(String name, [bool createIfMissing = false]) {
     File file = getChild(name);
     if (file != null) {


### PR DESCRIPTION
Address a few analysis warnings:
- some new dead code warnings in the git code
- some warnings due to clients using `getOrCreateFile` on `Container`s, but that method only being available on `Folder`s. Moved an abstract definition up to to Container; kept the concrete impl on Folder.

@ussuri
