### PR TITLE
Use 'pub upgrade' instead of 'pub get' in `grind setup`

### DIFF
--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -70,7 +70,7 @@ void setup(GrinderContext context) {
   }
 
   PubTools pub = new PubTools();
-  pub.get(context);
+  pub.upgrade(context);
 
   // Copy from ./packages to ./app/packages.
   copyDirectory(getDir('packages'), getDir('app/packages'), context);


### PR DESCRIPTION
@devoncarew 

With `pub get`, `grind setup-boot` wouldn't import fresh changes from /widgets, for example.
