### PR TITLE
Support empty git repos

### DIFF
--- a/ide/app/lib/git/objectstore.dart
+++ b/ide/app/lib/git/objectstore.dart
@@ -193,7 +193,7 @@ class ObjectStore {
   Future<String> getHeadForRef(String headRefName) {
     return FileOps.readFileText(_rootDir, gitPath + headRefName).then((content) {
       return content.substring(0,40);
-      }, onError: (e) {
+    }, onError: (e) {
       if (headRefName == HEAD_MASTER_REF_PATH) {
         return new Future.value(HEAD_MASTER_SHA);
       } else {
@@ -549,7 +549,6 @@ class ObjectStore {
           return _initHelper();
         });
       }, onError: (e) {
-        print(e);
         throw e;
       });
     }, onError: (e) {


### PR DESCRIPTION
This fixes various issues for the case when an empty repository was throwing an error on committing  changes.

I was able to clone a empty repo, do some changes, create and switch branches and finally push the first commit to the repo.

TODO: the empty repo still appear to be dirty as if there are un-committed changes. Looking into it.

Fixes #3150 
@devoncarew 
