### PR TITLE
work around mouse cursor issue

### DIFF
--- a/ide/app/lib/ace.dart
+++ b/ide/app/lib/ace.dart
@@ -639,11 +639,6 @@ class AceManager {
       _markerSession = currentSession;
       _linkingMarkerId = _markerSession.addMarker(markerRange,
           "ace_link_marker", type: ace.Marker.TEXT);
-
-      // If we are hovering, we can assume that the mouse is over the identifier.
-      contentElement.style.cursor = "pointer";
-    } else {
-      contentElement.style.cursor = null;
     }
   }
 


### PR DESCRIPTION
Work around https://github.com/dart-lang/chromedeveditor/issues/2805. This still leaves the underline on an element, but the mouse cursor is no longer stuck on the hand. Might need changes to ace for a real fix.

@umop
