### PR TITLE
fix an issue with dart2js and spaces in the path

### DIFF
--- a/ide/app/lib/launch.dart
+++ b/ide/app/lib/launch.dart
@@ -1083,8 +1083,9 @@ String _createTextForError(File file, CompileResult result) {
   buf.write('Error compiling ${file.path}:<br><br>');
 
   for (CompileError problem in result.problems) {
-    buf.write('[${problem.kind}] ${problem.message} '
-        '(${problem.file.path}:${problem.line})<br>');
+    String path = problem.file == null ? '' : problem.file.path;
+    buf.write(
+        '[${problem.kind}] ${problem.message} (${path}:${problem.line})<br>');
   }
 
   return buf.toString();

--- a/ide/app/lib/services.dart
+++ b/ide/app/lib/services.dart
@@ -160,6 +160,8 @@ class _ServicesUuidResolver extends UuidResolver {
   _ServicesUuidResolver(this.packageManager, [this.project]);
 
   File getResource(String uri) {
+    if (uri.isEmpty) return null;
+
     if (uri.startsWith('/')) uri = uri.substring(1);
 
     if (uri.startsWith('package:')) {

--- a/ide/app/lib/services/compiler.dart
+++ b/ide/app/lib/services/compiler.dart
@@ -243,7 +243,9 @@ class _CompilerProvider {
         return new Future.error('file not found');
       }
     } else if (uri.scheme == 'file') {
-      return provider.getFileContents(uri.path);
+      // We use uri.pathSegments.join('/') instead of uri.path in order to get
+      // the unencoded path (we want spaces, not %20).
+      return provider.getFileContents(uri.pathSegments.join('/'));
     } else if (uri.scheme == 'package') {
       if (uuidInput == null) return new Future.error('file not found');
 

--- a/ide/app/lib/services/services_common.dart
+++ b/ide/app/lib/services/services_common.dart
@@ -6,9 +6,13 @@ library spark.services_common;
 
 import 'dart:async';
 
+import 'package:logging/logging.dart';
+
 import '../workspace.dart';
 import '../package_mgmt/package_manager.dart';
 import '../package_mgmt/pub.dart';
+
+final Logger _logger = new Logger('spark.services_common');
 
 /**
  * Defines a received action event.
@@ -156,7 +160,11 @@ class CompileResult {
     // Find all files.
     problems.forEach((CompileError error) {
       error.file = resolver.getResource(error._uri);
-      if (error.file != null) retriever.addFile(error.file);
+      if (error.file != null) {
+        retriever.addFile(error.file);
+      } else {
+        _logger.warning('no file associated with ${error}');
+      }
     });
 
     // Get content.


### PR DESCRIPTION
Fix an issue with spaces in the path (fixes https://github.com/dart-lang/chromedeveditor/issues/3090). dart2js had been returning us encoded paths (%20's) instead of spaces.

@gaurave
