### PR TITLE
Fix pubspec.yaml syntax around '-polymer --csp' flag

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -40,4 +40,4 @@ dev_dependencies:
 transformers:
 - polymer:
     entry_points: web/spark_polymer.html
-    csp: 'true'
+    csp: true


### PR DESCRIPTION
TBR

This should complete the list of all we can do in relation to #1978 on the code side (the other part being #3178). The rest will be fixed by upgrading to the new Polymer.
