### PR TITLE
Toggle spark-menu-button only if focus went outside of the menu.

### DIFF
--- a/widgets/lib/spark_menu_button/spark_menu_button.dart
+++ b/widgets/lib/spark_menu_button/spark_menu_button.dart
@@ -104,7 +104,12 @@ class SparkMenuButton extends SparkWidget {
 
   void focusHandler(Event e) => _toggle(true);
 
-  void blurHandler(Event e) => _toggle(false);
+  void blurHandler(FocusEvent e) {
+    var target = e.relatedTarget;
+    if (target != null && !contains(target)) {
+      _toggle(false);
+    }
+  }
 
   /**
    * Handle the on-opened event from the dropdown. It will be fired e.g. when


### PR DESCRIPTION
review @devoncarew

This fixes the following scenario:
1. Open main menu.
2. Press left button over "New Project..." and wait.
   
   Current behavior: menu closes after a fraction of a second.
   
   Expected behavior: do nothing and wait for mouse up.
