### PR TITLE
deployment timeout fix

### DIFF
--- a/ide/app/lib/mobile/adb.dart
+++ b/ide/app/lib/mobile/adb.dart
@@ -555,7 +555,7 @@ class AndroidDevice {
   // response, headers and all. In case of an error, rejects the Future with an
   // error message.
   // Technically this will work for sending any TCP request/response pair.
-  Future<List<int>> sendHttpRequest(List<int> httpRequest, int port, int timeout) {
+  Future<List<int>> sendHttpRequest(List<int> httpRequest, int port, Duration timeout) {
     int localID = 4; // Arbitrary choice.
     int remoteID;
     Queue<ByteData> responseChunks;
@@ -605,7 +605,7 @@ class AndroidDevice {
       responseChunks = new Queue<ByteData>();
 
       Future readChunk() {
-        return receive().timeout(new Duration(seconds: timeout)).then((msg) {
+        return receive().timeout(timeout).then((msg) {
           if (msg.command == AdbUtil.A_WRTE) {
             responseChunks.add(msg.dataBuffer);
             return sendMessage(new AdbMessage(AdbUtil.A_OKAY, localID,

--- a/ide/app/lib/mobile/deploy.dart
+++ b/ide/app/lib/mobile/deploy.dart
@@ -120,8 +120,8 @@ class MobileDeploy {
 
 abstract class AbstractDeployer {
   static const int DEPLOY_PORT = 2424;
-  static const int REGULAR_REQUEST_TIMEOUT = 2;
-  static const int PUSH_REQUEST_TIMEOUT = 60;
+  static Duration REGULAR_REQUEST_TIMEOUT = new Duration(seconds: 2);
+  static Duration PUSH_REQUEST_TIMEOUT = new Duration(seconds: 60);
 
   final Container appContainer;
   final PreferenceStore _prefs;
@@ -248,7 +248,7 @@ abstract class AbstractDeployer {
 
   /// This method sends the command to the device and it's
   /// implementation depends on the deployment choice
-  Future<List<int>> _pushRequestToDevice(List<int> httpRequest, int timeout);
+  Future<List<int>> _pushRequestToDevice(List<int> httpRequest, Duration timeout);
 
   /// Get the deployment target URL
   String _getTarget();
@@ -360,7 +360,7 @@ class USBDeployer extends AbstractDeployer {
     });
   }
 
-  Future<List<int>> _pushRequestToDevice(List<int> httpRequest, int timeout) {
+  Future<List<int>> _pushRequestToDevice(List<int> httpRequest, Duration timeout) {
     return _device.sendHttpRequest(httpRequest, DEPLOY_PORT, timeout);
   }
 
@@ -380,11 +380,11 @@ class HttpDeployer extends AbstractDeployer {
   HttpDeployer(Container appContainer, PreferenceStore _prefs, this._target)
      : super(appContainer, _prefs);
 
-  Future<List<int>> _pushRequestToDevice(List<int> httpRequest, int timeout) {
+  Future<List<int>> _pushRequestToDevice(List<int> httpRequest, Duration timeout) {
     TcpClient client;
     return TcpClient.createClient(_target, DEPLOY_PORT).then((TcpClient client) {
       client.write(httpRequest);
-      Stream st = client.stream.timeout(new Duration(seconds: timeout));
+      Stream st = client.stream.timeout(timeout);
       List<int> response = new List<int>();
       return st.forEach((List<int> data) {
         response.addAll(data);


### PR DESCRIPTION
Solves #2811,  #3094 and  #3023.

This patch differentiates the timeout period for the deployment depending on the request type. For the upload of the files the timeout considers not only the time required to send the files but also the time required for the device to process those files and send back the OK.
