### PR TITLE
disable build.dart

### DIFF
--- a/ide/build.dart
+++ b/ide/build.dart
@@ -2,15 +2,15 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:grinder/grinder.dart' as grinder;
+//import 'package:grinder/grinder.dart' as grinder;
 
-import 'tool/grind.dart' as grind;
+//import 'tool/grind.dart' as grind;
 
 void main() {
-  new grinder.Grinder()
-    ..addTask(new grinder.GrinderTask(
-        'update', taskFunction: grind.setup))
-    ..addTask(new grinder.GrinderTask(
-        'lint', taskFunction: grind.lint, depends: ['update']))
-    ..start(['lint']);
+//  new grinder.Grinder()
+//    ..addTask(new grinder.GrinderTask(
+//        'update', taskFunction: grind.setup))
+//    ..addTask(new grinder.GrinderTask(
+//        'lint', taskFunction: grind.lint, depends: ['update']))
+//    ..start(['lint']);
 }


### PR DESCRIPTION
@ussuri, disable the `build.dart` script for now. Our setup (w/ it active) causes endless building in the Editor. Would prefer that the on-boarding experience w/ people on the project didn't have this issue.
