### PR TITLE
Disable running apps on CrOS from google-drive.

### DIFF
--- a/ide/app/lib/launch.dart
+++ b/ide/app/lib/launch.dart
@@ -23,6 +23,7 @@ import 'exception.dart';
 import 'jobs.dart';
 import 'package_mgmt/package_manager.dart';
 import 'package_mgmt/pub.dart';
+import 'platform_info.dart';
 import 'server.dart';
 import 'services.dart';
 import 'utils.dart';
@@ -417,6 +418,12 @@ class ChromeAppLocalLaunchHandler extends LaunchTargetHandler {
     }
 
     Container container = application.primaryResource;
+
+    Pattern pattern = '/special/drive-';
+    if (PlatformInfo.isCros && container.entry.fullPath.startsWith(pattern)) {
+      return new Future.error(
+          'Unable to launch; Running a app from Google drive is not supported yet.');
+    }
 
     String idToLaunch;
 


### PR DESCRIPTION
This functionality is already available in chrome beta. Possibly check the version number of chrome here and selectively disable.

@devoncarew #3196 
