### PR TITLE
Disable load from drive for chrome < 38

### DIFF
--- a/ide/app/lib/launch.dart
+++ b/ide/app/lib/launch.dart
@@ -420,7 +420,9 @@ class ChromeAppLocalLaunchHandler extends LaunchTargetHandler {
     Container container = application.primaryResource;
 
     Pattern pattern = '/special/drive-';
-    if (PlatformInfo.isCros && container.entry.fullPath.startsWith(pattern)) {
+    //TODO(grv): remove after chrome 38 is stable.
+    if (PlatformInfo.chromeVersion < 38 && PlatformInfo.isCros &&
+        container.entry.fullPath.startsWith(pattern)) {
       return new Future.error(
           'Unable to launch; Running a app from Google drive is not supported yet.');
     }


### PR DESCRIPTION
Load from drive is available since chrome 38. Disable it for previous versions until 38 hits stable.
#3196

@devoncarew  TBR  (There was some problem in updating the previous PR)
