### PR TITLE
More app manifest validatation rules

### DIFF
--- a/ide/web/lib/apps/app_manifest_validator.dart
+++ b/ide/web/lib/apps/app_manifest_validator.dart
@@ -211,7 +211,7 @@ class ManifestVersionValueValidator extends IntegerValueValidator {
 
   @override
   void checkValue(JsonEntity entity, [StringEntity propertyName]) {
-    // The "manifest_version" type is always directly associted to an
+    // The "manifest_version" type is always directly associated to an
     // object key.
     assert(propertyName != null);
 
@@ -346,24 +346,21 @@ class PermissionValueValidator extends SchemaValidator {
              ErrorIds.OBSOLETE_ENTRY,
              entity.span,
              "Permission value \"${entity.text}\" is obsolete.");
-      }
-      else if (!_permissionNames.contains(entity.text) &&
+      } else if (!_permissionNames.contains(entity.text) &&
           !_isMatchPattern(entity.text)) {
         errorCollector.addMessage(
             ErrorIds.INVALID_PERMISSION,
             entity.span,
             "Permission value \"${entity.text}\" is not recognized.");
       }
-      return;
     } else if (entity is ObjectEntity) {
       // Validation has been performed by validator from "enterObject".
-      return;
+    } else {
+      errorCollector.addMessage(
+          ErrorIds.STRING_OR_OBJECT_EXPECTED,
+          entity.span,
+          "String or object expected for permission entries.");
     }
-
-    errorCollector.addMessage(
-        ErrorIds.STRING_OR_OBJECT_EXPECTED,
-        entity.span,
-        "String or object expected for permission entries.");
   }
 
   bool _isMatchPattern(String text) {
@@ -482,10 +479,8 @@ class SocketHostPatternValueValidator extends SchemaValidator {
     return false;
   }
 
-  static bool _isValidHost(String x) {
-    // Leave "host" part as free form.
-    return true;
-  }
+  // Leave "host" part as free form.
+  static bool _isValidHost(String x) => true;
 
   static bool _isValidPort(String x) {
     if (x == "" || x == "*") {
@@ -571,70 +566,24 @@ class Requirement3dFeatureValueValidator extends SchemaValidator {
  * See https://developer.chrome.com/webstore/i18n?csw=1#localeTable.
  */
 class LocaleValueValidator extends SchemaValidator {
-  static final Map<String, String> _validLocales = {
-    "ar": "Arabic",
-    "am": "Amharic",
-    "bg": "Bulgarian",
-    "bn": "Bengali",
-    "ca": "Catalan",
-    "cs": "Czech",
-    "da": "Danish",
-    "de": "German",
-    "el": "Greek",
-    "en": "English",
-    "en_GB": "English (Great Britain)",
-    "en_US": "English (USA)",
-    "es": "Spanish",
-    "es_419": "Spanish (Latin America and Caribbean)",
-    "et": "Estonian",
-    "fa": "Persian",
-    "fi": "Finnish",
-    "fil": "Filipino",
-    "fr": "French",
-    "gu": "Gujarati",
-    "he": "Hebrew",
-    "hi": "Hindi",
-    "hr": "Croatian",
-    "hu": "Hungarian",
-    "id": "Indonesian",
-    "it": "Italian",
-    "ja": "Japanese",
-    "kn": "Kannada",
-    "ko": "Korean",
-    "lt": "Lithuanian",
-    "lv": "Latvian",
-    "ml": "Malayalam",
-    "mr": "Marathi",
-    "ms": "Malay",
-    "nl": "Dutch",
-    "no": "Norwegian",
-    "pl": "Polish",
-    "pt_BR": "Portuguese (Brazil)",
-    "pt_PT": "Portuguese (Portugal)",
-    "ro": "Romanian",
-    "ru": "Russian",
-    "sk": "Slovak",
-    "sl": "Slovenian",
-    "sr": "Serbian",
-    "sv": "Swedish",
-    "sw": "Swahili",
-    "ta": "Tamil",
-    "te": "Telugu",
-    "th": "Thai",
-    "tr": "Turkish",
-    "uk": "Ukrainian",
-    "vi": "Vietnamese",
-    "zh_CN": "Chinese (China)",
-    "zh_TW": "Chinese (Taiwan)",
-  };
+  static final Set<int> _validCodeUnits = _getValidCodeUnits();
   final ErrorCollector errorCollector;
 
   LocaleValueValidator(this.errorCollector);
 
+  static Set<int> _getValidCodeUnits() {
+    final String validCharacters =
+        "abcdefghijklmnopqrstuvwxyz" +
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+        "1234567890" +
+        "-_";
+    return new Set<int>()..addAll(validCharacters.codeUnits);
+  }
+
   @override
   void checkValue(JsonEntity entity, [StringEntity propertyName]) {
     if (entity is StringEntity) {
-      if (_validLocales.containsKey(entity.text)) {
+      if (_isValidLocale(entity.text)) {
         return;
       }
     }
@@ -650,5 +599,17 @@ class LocaleValueValidator extends SchemaValidator {
           entity.span,
           "Locale is invalid for property \"${propertyName.text}\".");
     }
+  }
+
+  bool _isValidLocale(String text) {
+    if (text.length < 2)
+      return false;
+
+    for(int i = 0; i < text.length; i++) {
+      if (!_validCodeUnits.contains(text.codeUnitAt(0))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/ide/web/lib/json/json_schema_validator.dart
+++ b/ide/web/lib/json/json_schema_validator.dart
@@ -137,8 +137,7 @@ class CoreSchemaValidatorFactory implements SchemaValidatorFactory {
           if (propertySchema is! bool) {
             isValid = false;
           }
-        }
-        else if (!validateSchemaForTesting(propertySchema)) {
+        } else if (!validateSchemaForTesting(propertySchema)) {
           isValid = false;
         }
       });

--- a/ide/web/test/app_manifest_validator_test.dart
+++ b/ide/web/test/app_manifest_validator_test.dart
@@ -128,11 +128,38 @@ void defineTests() {
       _validate(contents, []);
     });
 
-    test('"default_locale" cannot be an arbitrary string', () {
+    test('"default_locale" may be a valid locale string with hyphen', () {
       String contents = """{
   "name": "foo",
   "version": "1",
-  "default_locale": "foo"
+  "default_locale": "en-US"
+} """;
+      _validate(contents, []);
+    });
+
+    test('"default_locale" may be a valid locale string with digits', () {
+      String contents = """{
+  "name": "foo",
+  "version": "1",
+  "default_locale": "es_419"
+} """;
+      _validate(contents, []);
+    });
+
+    test('"default_locale" cannot contain special characters', () {
+      String contents = """{
+  "name": "foo",
+  "version": "1",
+  "default_locale": "~!@#"
+} """;
+      _validate(contents, [ErrorIds.INVALID_LOCALE]);
+    });
+
+    test('"default_locale" cannot be a single character', () {
+      String contents = """{
+  "name": "foo",
+  "version": "1",
+  "default_locale": "a"
 } """;
       _validate(contents, [ErrorIds.INVALID_LOCALE]);
     });
@@ -216,8 +243,7 @@ void defineTests() {
   "version": "1",
   "sockets": { "foo": {} }
 }""";
-      _validate(
-          contents, []);
+      _validate(contents, []);
     });
 
     test('"sockets.udp" may contain 3 known top level properties', () {
@@ -236,8 +262,7 @@ void defineTests() {
   "version": "1",
   "sockets": { "udp": { "foo": "" } }
 }""";
-      _validate(
-          contents, []);
+      _validate(contents, []);
     });
 
     test('"sockets.tcp" may contain 1 known top level properties', () {
@@ -256,8 +281,7 @@ void defineTests() {
   "version": "1",
   "sockets": { "tcp": { "foo": "" } }
 }""";
-      _validate(
-          contents, []);
+      _validate(contents, []);
     });
 
     test('"sockets.tcpServer" may contain 1 known top level properties', () {
@@ -275,8 +299,7 @@ void defineTests() {
   "version": "1",
   "sockets": { "tcpServer": { "foo": "" } } 
 }""";
-      _validate(
-          contents, []);
+      _validate(contents, []);
     });
 
     test('"socket_host_pattern" may be a single value or an array', () {


### PR DESCRIPTION
- Add validation rules for the following manifest keys: default_locale, current_locale, kiosk_enabled, kiosk_only, minimum_chrome_version, requirements, version, webview
- Add validation for "socket_host_pattern"
- Minor code refactorings
- Support for mandatory properties and "open-ended" objects in json schema definition
- Lots of tests

@devoncarew
