### PR TITLE
Update cde to use Polymer 0.13.0.

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   markdown: '>=0.7.0 <0.8.0'
   mime: any
   path: any
-  polymer: '>=0.11.0 <0.12.0'
+  polymer: '>=0.13.0 <0.14.0'
   spark_widgets:
     path: ../widgets
   tavern:

--- a/ide/web/spark_bootstrap.dart
+++ b/ide/web/spark_bootstrap.dart
@@ -10,6 +10,7 @@ library spark.bootstrap;
 import 'package:polymer/polymer.dart';
 import 'package:spark_widgets/common/spark_widget.dart';
 import 'package:spark_widgets/spark_button/spark_button.dart';
+import 'package:spark_widgets/spark_icon/spark_icon.dart';
 import 'package:spark_widgets/spark_overlay/spark_overlay.dart';
 import 'package:spark_widgets/spark_dialog/spark_dialog.dart';
 import 'package:spark_widgets/spark_dialog_button/spark_dialog_button.dart';
@@ -37,6 +38,7 @@ void registerWidgetsWithPolymer() {
   // Register Polymer components (ones that are actually used in the app).
   Polymer.register('spark-widget', SparkWidget);
   Polymer.register('spark-button', SparkButton);
+  Polymer.register('spark-icon', SparkIcon);
   Polymer.register('spark-overlay', SparkOverlay);
   Polymer.register('spark-dialog', SparkDialog);
   Polymer.register('spark-dialog-button', SparkDialogButton);

--- a/widgets/pubspec.yaml
+++ b/widgets/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.0.0 <2.0.0'
 dependencies:
   bootjack: '>=0.6.5 <0.7.0'
-  polymer: '>=0.11.0 <0.12.0'
+  polymer: '>=0.13.0 <0.14.0'
 
 dev_dependencies:
   unittest: '>=0.11.0 <0.12.0'


### PR DESCRIPTION
Upgrade to polymer 0.13.0+3.

There was an issue where CDE would not starting up properly (infinite spinning wheel) when upgrading from polymer 0.12. The root cause was that we were not registering the "spark-icon" element even though we use it (transitively from spark-button) in the main CDE page.

The chain of events that lead to this problem was as follows:
- The Polymer.onReady future was never "completed", so cde would not finish initialization and switch to the main UI. He is the cde code:
  
  return polymer.Polymer.onReady.then((_) {
    spark.uiReady();
    return spark.init();
  });
- It seems (not 100% sure) out that "onReady" is called when the "polymer-ready" event is fired.
  
  whenPolymerReady(function() {
    document.body.removeAttribute('unresolved');
    document.dispatchEvent(
      new CustomEvent('polymer-ready', {bubbles: true})
    );
  });
- The definition of "whenPolymerReady" is as follows:
  
  function whenPolymerReady(callback) {
    queue.waitToReady = true;
    CustomElements.ready = false;
    HTMLImports.whenImportsReady(function() {
      queue.addReadyCallback(callback);
      queue.waitToReady = false;
      queue.check();
    });
  }

This means that "callback" (the function that fires the "polymer-ready" event) is called when the "queue" object is ready.
- The "queue.check()" function does the following:
  
  check: function() {
    (...)
    if (this.canReady()) {
      this.ready();
      return true;
    }
  },
- the "canReady()" function was never returning "true", hence the event was never fired.
  
  canReady: function() {
    return !this.waitToReady && this.isEmpty();
  },
  - the "isEmpty" function was never returning true because the "elements" array contained at least one element with a "queue.flushable" to false.
    
    isEmpty: function() {
      for (var i=0, l=elements.length, e; (i<l) &&
          (e=elements[i]); i++) {
        if (e.__queue && !e.__queue.flushable) {
          return;
        }
      }
      return true;
    },
-  After some investigation, it turns out that element was the "spark-icon" element, which is used in the Spark main ui page, but never registered. To be "flushable", the "go" method must be called.
  
  // tell the queue an element is ready to be registered
  go: function(element) {
    var readied = this.remove(element);
    if (readied) {
      element.__queue.flushable = true;
      this.addToFlushQueue(readied);
      this.check();
    }
  },

How we figured this out:
- It turns out that it is possible to add manual logging in Dart packages, because they reside as source on disk.
  - For dart code, adding a "print" statement will log in both the Dartium console, and in the Dart editor output window.
  - For JavaScript code (poylmer in this case), using "console.log" will also log to both outout.
- The first thing we did was change packages/polymer/src/js/polymer/polymer.html to load "polymer.concat.js" instead of "polymer.js", because polymer.js is minified and close to impossible to modify manually.

Note: Every change to the source code of a Dart packages (e.g. polymer), wheter it is Dart or JavaScript cdeo requires to run "grind setup" for the change to take effect on Spark if running in Dartium from the Dart Editor.
- Once this is done, locating the bug was a matter of adding log statements in the Dart and JavaScript code to figure out why the "polymer-ready" event was never fired.

@ussuri @devoncarew 
