### PR TITLE
Added offline_enabled to manifest

### DIFF
--- a/ide/web/manifest.json
+++ b/ide/web/manifest.json
@@ -3,6 +3,7 @@
   "name": "__MSG_app_name__",
   "short_name": "__MSG_app_name__",
   "description": "__MSG_app_description__",
+  "offline_enabled": true,
   "version": "0.15.0",
   "minimum_chrome_version": "36",
   "manifest_version": 2,


### PR DESCRIPTION
Even though chrome apps are assumed to be offline enabled (https://developer.chrome.com/apps/manifest/offline_enabled), I think it's better to add it so that the Chrome Dev Editor appears in the "Offline section" when searching for "Chrome Dev Editor" in the Chrome Web Store.

See https://chrome.google.com/webstore/search-apps/chrome%20dev%20editor/offline
