### PR TITLE
fix an issue with dart chrome apps

### DIFF
--- a/ide/web/lib/launch.dart
+++ b/ide/web/lib/launch.dart
@@ -782,7 +782,7 @@ class DartChromeAppParticipant extends LaunchParticipant {
 
           if (!result.getSuccess()) throw new SparkException('${result}');
 
-          String newFileName = '${file.name}.precompiled.js';
+          String newFileName = '${file.name}.js';
           return file.parent.getOrCreateFile(newFileName, true);
         }).then((File newFile) {
           return newFile.setContents(result.output);

--- a/ide/web/spark.dart
+++ b/ide/web/spark.dart
@@ -3637,7 +3637,7 @@ class CompileDartJob extends Job {
         throw result;
       }
 
-      String newFileName = '${file.name}.precompiled.js';
+      String newFileName = '${file.name}.js';
       return file.parent.getOrCreateFile(newFileName, true).then((ws.File file) {
         return file.setContents(result.output);
       });


### PR DESCRIPTION
@rpaquay Address an issue with the csp compiled files for dart2js changing from foo.dart.precompiled.js to foo.dart.js (https://github.com/dart-lang/chromedeveditor/issues/3335).
