### PR TITLE
For `focused` elements in widgets, also auto-select current text where possible

### DIFF
--- a/widgets/lib/common/spark_widget.dart
+++ b/widgets/lib/common/spark_widget.dart
@@ -113,11 +113,12 @@ class SparkWidget extends PolymerElement {
   void _applyAutofocus(bool isFocused) {
     if (_focusableChild != null) {
       if (isFocused) {
-        try {
-          // <textarea> and some variants of <input> support select(), which is
-          // focus() + make the current text selected.
+        if (_focusableChild is InputElement ||
+            _focusableChild is TextAreaElement) {
+          // <textarea> and some types of <input> support select(), which is
+          // focus() + make the current text selected. Falls back to focus().
           (_focusableChild as dynamic).select();
-        } catch (NoSuchMethod) {
+        } else {
           // If the above fails, just focus the element.
           _focusableChild.focus();
         }


### PR DESCRIPTION
@devoncarew 

`<textarea>` and `<input type="text">` and possible some others support `select()` in addition to `focus()`, which also selects the current text in the element. Make use of that.

This is a small thing which I've added by accident while addressing a bug which didn't actually call for it, but it's still potentially useful.
