### PR TITLE
Switched from `autosave` to `autocomplete` in <input> elements

### DIFF
--- a/ide/web/spark_polymer_ui.html
+++ b/ide/web/spark_polymer_ui.html
@@ -196,7 +196,7 @@
       <label for="renameFileName">New name</label>
       <input id="renameFileName" type="text" class="form-control"
           required pattern="[\w\.-]+"
-          spellcheck="false" autosave focused>
+          spellcheck="false" autocomplete="on" focused>
 
       <spark-dialog-button cancel>Cancel</spark-dialog-button>
       <spark-dialog-button submit>Rename</spark-dialog-button>
@@ -230,7 +230,7 @@
         <label for="name">Project name</label>
         <input id="name" type="text" class="form-control"
             placeholder="HelloWorld" required pattern="[\w\.-]+"
-            spellcheck="false" autosave focused />
+            spellcheck="false" autocomplete="on" focused />
       </div>
       <div class="form-group">
         <label for="type">Project type</label>
@@ -242,7 +242,7 @@
         -->
         <template if="{{showWipProjectTemplates}}">
           <!-- TODO(ussuri): Rename "type" - too generic => dangerous. -->
-          <select name="type" class="form-control" autosave>
+          <select name="type" class="form-control" autocomplete="on">
             <optgroup label="Default">
               <option value="empty">
                 Blank project
@@ -298,7 +298,7 @@
         </template>
 
         <template if="{{!showWipProjectTemplates}}">
-          <select name="type" class="form-control" autosave>
+          <select name="type" class="form-control" autocomplete="on">
             <optgroup label="Default">
               <option value="empty">
                 Blank project
@@ -363,19 +363,19 @@
           <label for="appName">App Name:</label>
           <input id="appName" type="text" class="form-control"
               placeholder="HelloWorld"
-              spellcheck="false" autosave>
+              spellcheck="false" autocomplete="on">
         </div>
         <div class="input-label">
           <label for="packageName">Package Name:</label>
           <input id="packageName" type="text" class="form-control"
               placeholder="com.example.helloworld"
-              spellcheck="false" autosave>
+              spellcheck="false" autocomplete="on">
         </div>
         <div class="input-label">
           <label for="versionName">Version:</label>
           <input id="versionName" type="text" class="form-control"
               placeholder="1.0"
-              spellcheck="false" autosave focused>
+              spellcheck="false" autocomplete="on" focused>
         </div>
       </div>
       <div class="form-group">
@@ -406,21 +406,25 @@
       </div>
       <div class="form-group">
         <div class="vert-align-box">
-          <input id="buildTargetADB" type="radio" name="mobileBuildType" value="build-target-adb" checked>
+          <input type="radio" id="buildTargetADB"
+              name="mobileBuildType" value="build-target-adb" checked>
           <label for="buildTargetADB">Build via USB</label>
         </div>
       </div>
       <div class="form-group">
         <div class="vert-align-box">
-          <input id="buildTargetIP" type="radio" name="mobileBuildType" value="build-target-ip">
-          <label for="buildTargetIP">Build via a network host with this IP:</label>
+          <input type="radio" id="buildTargetIP"
+              name="mobileBuildType" value="build-target-ip">
+          <label for="buildTargetIP">
+            Build via a network host with this IP:
+          </label>
         </div>
         <div class="radio-button-dependency">
           <!-- TODO(devoncarew): Also, support IPv6 name patterns. -->
           <input id="buildTargetUrl" type="text" class="form-control"
               placeholder="e.g. 192.168.1.101"
               pattern="(\d{1,3}\.){3}\d{1,3}"
-              spellcheck="false" autosave>
+              spellcheck="false" autocomplete="on">
         </div>
       </div>
       <div id="buildProgressDescription"></div>
@@ -461,7 +465,7 @@
           <input id="pushUrl" type="text" class="form-control "
               placeholder="e.g. 192.168.1.101"
               pattern="(\d{1,3}\.){3}\d{1,3}"
-              spellcheck="false" autosave>
+              spellcheck="false" autocomplete="on">
         </div>
       </div>
       <template if="{{liveDeployMode}}">
@@ -486,7 +490,7 @@
         <!-- TODO(devoncarew): Swap this out for a sample application repo? -->
         <input id="gitRepoUrl" type="url" class="form-control"
             placeholder="https://github.com/dart-lang/chromedeveditor.git"
-            spellcheck="false" autosave focused>
+            spellcheck="false" autocomplete="on" focused>
         <input id="gitRepoUrlCopyInBuffer"/>
       </div>
 
@@ -502,12 +506,13 @@
             <label for="gitName">Your name</label>
             <input id="gitName" type="text" class="form-control"
                 placeholder="John Doe" pattern=".+"
-                spellcheck="false" autosave>
+                spellcheck="false" autocomplete="on">
           </div>
           <div class="input-label">
             <label for="gitEmail">Email</label>
             <input id="gitEmail" type="email" class="form-control"
-                placeholder="johndoe@gmail.com" spellcheck="false" autosave>
+                placeholder="johndoe@gmail.com"
+                spellcheck="false" autocomplete="on">
           </div>
         </div>
       </div>
@@ -522,7 +527,8 @@
       <div class="form-group">
         <label for="commitMessage">Commit message</label>
         <textarea id="commitMessage" type="text" class="form-control"
-            rows="3" wrap="soft" spellcheck autosave focused></textarea>
+            rows="3" wrap="soft" spellcheck autocomplete="on" focused>
+        </textarea>
         <span class="help-block">
           Enter a brief description of the changes.
         </span>
@@ -535,7 +541,8 @@
     <spark-dialog id="gitBranchDialog" headerTitle="Create Branch">
       <label for="gitBranchName">Create a new branch</label>
       <input id="gitBranchName" type="text" class="form-control"
-          required pattern="[^~:?*\^\[\s]+" spellcheck="false" autosave focused>
+          required pattern="[^~:?*\^\[\s]+"
+          spellcheck="false" autocomplete="on" focused>
       <div class="form-group">
         <label for="gitRemoteBranches">Checkout a branch</label>
         <select id="gitRemoteBranches" class="form-control"></select>
@@ -548,7 +555,8 @@
     <spark-dialog id="gitMergeDialog" headerTitle="Merge Branch">
       <label for="gitBranchName">Current branch</label>
       <input id="gitBranchName" type="text" class="form-control"
-          required pattern="[^~:?*\^\[\s]+" spellcheck="false" autosave focused>
+          required pattern="[^~:?*\^\[\s]+"
+          spellcheck="false" autocomplete="on" focused>
       <div class="form-group">
         <label for="gitBranches">Select branch to merge </label>
         <select id="gitBranches" class="form-control"></select>
@@ -600,8 +608,8 @@
             <input id="analyticsCheck" type="checkbox">
           </span>
           <label for="analyticsCheck">
-            Help make Chrome Dev Editor better by automatically sending usage statistics and
-            crash reports to Google
+            Help make Chrome Dev Editor better by automatically sending usage
+            statistics and crash reports to Google
           </label>
         </div>
       </div>
@@ -740,7 +748,7 @@
           <label for="gitUsername">User name</label>
           <input id="gitUsername" type="text" class="form-control"
               placeholder="johndoe" required pattern="\S+"
-              spellcheck="false" autosave focused>
+              spellcheck="false" autocomplete="on" focused>
         </div>
         <div class="input-label">
           <label for="gitPassword">Password</label>
@@ -759,23 +767,28 @@
     </spark-dialog>
 
     <!-- Publish on webstore -->
-    <spark-dialog id="webStorePublishDialog" headerTitle="Publish to Chrome Web Store">
+    <spark-dialog id="webStorePublishDialog"
+        headerTitle="Publish to Chrome Web Store">
       <div class="form-group">
         <div class="vert-align-box">
-          <input type="radio" name="webStorePublishType" value="new" id="new-app-radio" checked>
+          <input type="radio" id="new-app-radio"
+              name="webStorePublishType" value="new" checked>
           <label for="new-app-radio">Create a new application</label>
         </div>
       </div>
       <div class="form-group">
         <div class="vert-align-box">
-          <input type="radio" name="webStorePublishType" value="existing" id="existing-app-radio">
-          <label for="existing-app-radio">Upload to an existing application with this ID:</label>
+          <input type="radio" id="existing-app-radio"
+              name="webStorePublishType" value="existing">
+          <label for="existing-app-radio">
+            Upload to an existing application with this ID:
+          </label>
         </div>
         <div class="radio-button-dependency">
           <input id="appID" type="text" class="form-control"
               placeholder="abcdefghijklmnopqrstuvwxyzabcdef"
               required pattern="[a-z]{32}"
-              spellcheck="false" autosave>
+              spellcheck="false" autocomplete="on">
         </div>
       </div>
       <spark-dialog-button cancel>Cancel</spark-dialog-button>

--- a/widgets/lib/spark_dialog/spark_dialog.html
+++ b/widgets/lib/spark_dialog/spark_dialog.html
@@ -33,7 +33,7 @@
         </template>
       </spark-toolbar>
 
-      <form id="body">
+      <form id="body" autocomplete="on">
         <content id="bodyContent" select=":not(spark-dialog-button)"></content>
       </form>
 


### PR DESCRIPTION
@devoncarew 

`autocomplete` doesn't work as advertised either, but at least it's how preserving previously entered values is supposed to be done (`autosave` was completely wrong: it's only for `<input type="search">`, and is barely supported by browsers).

I'll file a bug about `autocomplete` not working right after landing this.
