### PR TITLE
Fix running Bower commands on project's subdirectories

### DIFF
--- a/ide/web/lib/package_mgmt/bower.dart
+++ b/ide/web/lib/package_mgmt/bower.dart
@@ -41,10 +41,10 @@ class BowerManager extends PackageManager {
       new _BowerResolver._(project);
 
   Future installPackages(Folder container, ProgressMonitor monitor) =>
-      _installOrUpgradePackages(container.project, FetchMode.INSTALL, monitor);
+      _installOrUpgradePackages(container, FetchMode.INSTALL, monitor);
 
   Future upgradePackages(Folder container, ProgressMonitor monitor) =>
-      _installOrUpgradePackages(container.project, FetchMode.UPGRADE, monitor);
+      _installOrUpgradePackages(container, FetchMode.UPGRADE, monitor);
 
   // TODO(keertip): implement for bower
   Future<dynamic> arePackagesInstalled(Folder container) =>


### PR DESCRIPTION
TBR: @keertip 

Even when a Bower command was invoked on a bower.json in a project's subdirectory, the Bower implementation would always look for it in the project's root, not find it there, and get stuck with an error in the console.
