### PR TITLE
make the file save more faster on large files

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   chrome_testing: '>=0.1.0 <0.2.0'
   cipher: '>=0.7.0 <0.8.0'
   compiler_unsupported: 0.7.2
-  crc32: any
+  crc32: '>=0.1.5 <0.2.0'
   crypto: any
   diff: '>=0.1.0 <0.2.0'
   html5lib: any

--- a/ide/web/lib/ace.dart
+++ b/ide/web/lib/ace.dart
@@ -40,6 +40,7 @@ export 'package:ace/ace.dart' show EditSession;
 
 class TextEditor extends Editor {
   static final RegExp whitespaceRegEx = new RegExp('[\t ]*\$', multiLine:true);
+  static const int LARGE_FILE_SIZE = 500000;
 
   final AceManager aceManager;
   final workspace.File file;
@@ -209,8 +210,6 @@ class TextEditor extends Editor {
       });
     }
   }
-
-  static const int LARGE_FILE_SIZE = 30000;
 
   bool fileIsLarge(String text) {
     return (text.length > LARGE_FILE_SIZE);

--- a/ide/web/test/benchmarks.dart
+++ b/ide/web/test/benchmarks.dart
@@ -57,7 +57,7 @@ defineTests() {
     test('git sha', () => runBenchmark(new GitShaBenchmark()));
     test('fast sha', () => runBenchmark(new FastShaBenchmark()));
     test('crc32', () => runBenchmark(new CRC32Benchmark()));
-    test('md5', () => runBenchmark(new md5Benchmark()));
+    test('MD5', () => runBenchmark(new MD5Benchmark()));
   });
 }
 
@@ -192,10 +192,10 @@ class FastShaBenchmark extends BenchmarkBase {
   }
 }
 
-class md5Benchmark extends BenchmarkBase {
+class MD5Benchmark extends BenchmarkBase {
   String data = _createLargeString(100000);
 
-  md5Benchmark() : super('md5', emitter: _emitter);
+  MD5Benchmark() : super('MD5', emitter: _emitter);
 
   void run() {
     crypto.MD5 md5 = new crypto.MD5();


### PR DESCRIPTION
It improves the saving speed by using crc32 instead of md5 and also disables the "delete white spaces" on large files.

this PR doesn't solve #3028

review @devoncarew 
