### PR TITLE
move tests from a top level project to ide/test

### DIFF
--- a/ide/test/cli_tests.dart
+++ b/ide/test/cli_tests.dart
@@ -2,9 +2,11 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import '../../ide/web/test/app_manifest_validator_test.dart' as app_manifest_validator_test;
-import '../../ide/web/test/json_parser_test.dart' as json_parser_test;
-import '../../ide/web/test/json_validator_test.dart' as json_validator_test;
+// TODO(devoncarew): Change these to package imports when we're able.
+
+import '../web/test/app_manifest_validator_test.dart' as app_manifest_validator_test;
+import '../web/test/json_parser_test.dart' as json_parser_test;
+import '../web/test/json_validator_test.dart' as json_validator_test;
 
 void main() {
   app_manifest_validator_test.defineTests();

--- a/test/pubspec.yaml
+++ b/test/pubspec.yaml
@@ -1,4 +1,0 @@
-name: unittest_runner
-description: Test runner for Spark unit tests
-dependencies:
-  unittest: any


### PR DESCRIPTION
@rpaquay, move the command-line tests script from a top-level repo directory to `ide/test`. This will let use debug though the tests w/o issues finding the source.

After a bit more repo restructuring we'll be able to use package: imports for these, and avoid using relative paths to climb out of the `test` directory.
