### PR TITLE
fix a bug saving state for un-realized tabs

### DIFF
--- a/ide/web/lib/ace.dart
+++ b/ide/web/lib/ace.dart
@@ -176,6 +176,8 @@ class TextEditor extends Editor {
       new Future.value(svc.Declaration.EMPTY_DECLARATION);
 
   void saveState() {
+    if (_session == null) return;
+
     html.Point p = aceManager.cursorPosition;
     state.setState(file.uuid, {
       'scrollTop': _session.scrollTop,


### PR DESCRIPTION
fixes https://github.com/dart-lang/chromedeveditor/issues/3450

This was caused by trying to save state for an editor that had never had it's contents realized.
