### PR TITLE
fix for the outline view button

### DIFF
--- a/widgets/lib/spark_button/spark_button.dart
+++ b/widgets/lib/spark_button/spark_button.dart
@@ -19,7 +19,10 @@ class SparkButton extends SparkWidget {
   @published bool primary;
   @published_reflected String padding;
   @published_reflected String hoverStyle;
-  @published_reflected bool disabled = false;
+
+  @published bool get disabled => attributes.containsKey('disabled');
+  @published set disabled(bool value) => setAttr('disabled', value);
+
   @published bool active;
   @published String tooltip;
   @published String command;


### PR DESCRIPTION
Fix https://github.com/dart-lang/chromedeveditor/issues/3464

The toggle outline view button is disabled in the deployed version.
