### PR TITLE
don't add secondary packages on windows

### DIFF
--- a/ide/web/lib/files_mock.dart
+++ b/ide/web/lib/files_mock.dart
@@ -143,6 +143,7 @@ DirectoryEntry createSampleDirectory2(String name) {
 DirectoryEntry createSampleDirectory3(String name) {
   MockFileSystem fs = new MockFileSystem();
   DirectoryEntry directory = fs.createDirectory(name);
+  fs.createFile('${name}/pubspec.yaml', contents: 'name: ${name}\n');
   fs.createFile('${name}/web/index.html', contents:
       '<html><body><script type="application/dart" src="sample.dart"></script></body></html>');
   fs.createFile('${name}/web/sample.dart', contents:

--- a/ide/web/lib/workspace.dart
+++ b/ide/web/lib/workspace.dart
@@ -20,7 +20,6 @@ import 'builder.dart';
 import 'enum.dart';
 import 'exception.dart';
 import 'jobs.dart';
-import 'package_mgmt/pub.dart';
 import 'preferences.dart';
 import 'utils.dart';
 
@@ -508,10 +507,9 @@ class Workspace extends Container {
           // directories on Windows. We only want to realize the packages
           // directory at the top level of a project. Our check for this is the
           // existance of a `pubspec.yaml` file.
-          if (ent.name == pubProperties.packagesDirName) {
+          if (ent.name == 'packages') {
             if (hasPubspec == null) {
-              hasPubspec = entries.any(
-                  (e) => e.name == pubProperties.packageSpecFileName);
+              hasPubspec = entries.any((e) => e.name == 'pubspec.yaml');
             }
 
             // Ignore secondary packages directories.

--- a/ide/web/test/pub_test.dart
+++ b/ide/web/test/pub_test.dart
@@ -23,7 +23,7 @@ defineTests() {
       return workspace.link(createWsRoot(dir)).then((Project _project) {
         project = _project;
         pubManager = new PubManager(workspace);
-        return project.createNewFile('pubspec.yaml');
+        return project.getChild('pubspec.yaml');
       }).then((File file) {
         return file.setContents('name: sample\nversion: 0.1.0\n');
       }).then((_) {
@@ -86,6 +86,7 @@ DirectoryEntry _createSampleDirectory([String projectName = 'sample_project']) {
   MockFileSystem fs = new MockFileSystem();
   DirectoryEntry project = fs.createDirectory(projectName);
   fs.createFile('${projectName}/bar.txt');
+  fs.createFile('${projectName}/pubspec.yaml');
   fs.createFile('${projectName}/packages/foo/foo.dart', contents: 'foo() { }');
   fs.createFile('${projectName}/lib/sample.dart', contents: 'sample() { }');
   fs.createFile('${projectName}/web/index.html');


### PR DESCRIPTION
Add some code in workspace.dart to ignore secondary packages directories on windows. These folders contain copies of the entire packages/ directory contents. With a lot of packages, and many symlinked subfolders, the workspace can grow to enormous sizes. Just refreshing all the folders for CDE can take ~1 minute.

@keertip 
