### PR TITLE
Adjust template to Polymer/platform having moved to Polymer/webcomponents #2

### DIFF
--- a/ide/web/lib/templates/chrome/chrome_app_polymer_js/index.html_
+++ b/ide/web/lib/templates/chrome/chrome_app_polymer_js/index.html_
@@ -4,7 +4,7 @@
 <head>
   <title>``projectName``</title>
 
-  <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+  <script src="bower_components/platform/platform.js"></script>
 
   <link rel="import" href="bower_components/core-icons/core-icons.html">
   <link rel="import" href="bower_components/core-toolbar/core-toolbar.html">

--- a/ide/web/lib/templates/polymer/polymer_element_js/bower.json_
+++ b/ide/web/lib/templates/polymer/polymer_element_js/bower.json_
@@ -2,6 +2,7 @@
   "name": "``projectName``",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#master"
+    "polymer": "Polymer/polymer#master",
+    "platform": "Polymer/platform#master"
   }
 }

--- a/ide/web/lib/templates/polymer/polymer_element_js/demo.html_
+++ b/ide/web/lib/templates/polymer/polymer_element_js/demo.html_
@@ -4,7 +4,7 @@
 <head>
   <title>``tagName`` Demo</title>
 
-  <script src="../webcomponentsjs/webcomponents.js"></script>
+  <script src="../platform/platform.js"></script>
 
   <link rel="import" href="``sourceName``.html">
 </head>

--- a/ide/web/lib/templates/polymer/polymer_element_js/index.html_
+++ b/ide/web/lib/templates/polymer/polymer_element_js/index.html_
@@ -4,7 +4,7 @@
 <head>
   <title>``tagName`` Info</title>
 
-  <script src="../webcomponentsjs/webcomponents.js"></script>
+  <script src="../platform/platform.js"></script>
 
   <link rel="import" href="../polymer/polymer.html">
   <link rel="import" href="../core-component-page/core-component-page.html">

--- a/ide/web/lib/templates/web/web_app_polymer_js/bower.json_
+++ b/ide/web/lib/templates/web/web_app_polymer_js/bower.json_
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "polymer": "Polymer/polymer#master",
+    "platform": "Polymer/platform#master",
     "paper-elements": "Polymer/paper-elements#master"
   }
 }

--- a/ide/web/lib/templates/web/web_app_polymer_js/index.html_
+++ b/ide/web/lib/templates/web/web_app_polymer_js/index.html_
@@ -8,7 +8,7 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
 
-  <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+  <script src="bower_components/platform/platform.js"></script>
 
   <link rel="import" href="bower_components/core-icons/core-icons.html">
   <link rel="import" href="bower_components/core-toolbar/core-toolbar.html">


### PR DESCRIPTION
TBR: expediting this per request from the Polymer team for a GDG event tomorrow.

It turns out Polymer is in a bit of a flux right now: the switch to Polymer/webcomponents is incomplete; Polymer/webcomponents itself is not officially released yet, so Polymer/paper-elements still depend on Polymer/platform, but Polymer/polymer no longer includes /platform, so it needs to be imported explicitly in bower.json.

After the switch is complete, this PR should be undone to the way the code was right before it.
