### PR TITLE
Bump minimum required Chrome version to 38

### DIFF
--- a/ide/web/manifest.json
+++ b/ide/web/manifest.json
@@ -5,7 +5,7 @@
   "description": "__MSG_app_description__",
   "offline_enabled": true,
   "version": "0.17.0",
-  "minimum_chrome_version": "36",
+  "minimum_chrome_version": "38",
   "manifest_version": 2,
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
@devoncarew: I think it's time. One codelab that's happened over the last weekend reported problems with project creation in Chrome 36, so they created one in 38 on one machine and shared it with everyone as a zip.
