### PR TITLE
Unbump minimum required Chrome version one step back to 37

### DIFF
--- a/ide/web/manifest.json
+++ b/ide/web/manifest.json
@@ -5,7 +5,7 @@
   "description": "__MSG_app_description__",
   "offline_enabled": true,
   "version": "0.17.0",
-  "minimum_chrome_version": "38",
+  "minimum_chrome_version": "37",
   "manifest_version": 2,
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
TBR @devoncarew, @sunglim. Partially revert #3569.
