### PR TITLE
Fix right-most tabs randomly becoming invisible

### DIFF
--- a/widgets/lib/common/spark_widget.css
+++ b/widgets/lib/common/spark_widget.css
@@ -5,7 +5,8 @@
 @import url("../resources/roboto/roboto.css");
 
 :host,
-:host * {
+:host *,
+::content * {
   box-sizing: border-box;
   outline: none;
 }


### PR DESCRIPTION
@devoncarew 

Partially reverted from commit 6191a2b4cb10ffe1d8f372fdf2d42e10976d1a82 "address comments", which was a follow-up to 7bc0ad42042cfb138922f4f76ccc2c74c473f3c2 "remove bootstrap"

It turns out we rushed too much with this. Somehow this caused the right-most tabs in the tab bar to randomly disappear (more often than not) when the tab bar was 100% filled.

Compare before the rollback:

![screen shot 2014-10-22 at 10 00 08 pm](https://cloud.githubusercontent.com/assets/5606182/4748516/3e0dfb88-5a72-11e4-97b4-b1caba197912.png)

to after the rollback:

![screen shot 2014-10-22 at 10 00 39 pm](https://cloud.githubusercontent.com/assets/5606182/4748517/4af17820-5a72-11e4-9f10-8362ccf4821b.png)

I could try to come up with a more precise solution, but I'm overloaded right now. We could land this now and file an issue to track the problem down later.
