### PR TITLE
remove underlines from outline items

### DIFF
--- a/ide/web/spark_polymer.css
+++ b/ide/web/spark_polymer.css
@@ -604,7 +604,6 @@ button.ace_searchbtn[action="findAll"] {
 }
 
 .outlineItem a:hover {
-  white-space: nowrap;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
@umop, fix https://github.com/dart-lang/chromedeveditor/issues/3587, a recent regression in the outline view UI
