### PR TITLE
Add .sql and .sqlite to supported Ace extensions

### DIFF
--- a/ide/web/lib/ace.dart
+++ b/ide/web/lib/ace.dart
@@ -624,6 +624,8 @@ class AceManager {
     ace.Mode.extensionMap['webapp'] = ace.Mode.JSON;
     ace.Mode.extensionMap['gsp'] = ace.Mode.HTML;
     ace.Mode.extensionMap['jsp'] = ace.Mode.HTML;
+    ace.Mode.extensionMap['sql'] = ace.Mode.SQL;
+    ace.Mode.extensionMap['sqlite'] = ace.Mode.SQL;
     // The extensions used in Spark's own internal templates.
     ace.Mode.extensionMap['html_'] = ace.Mode.HTML;
     ace.Mode.extensionMap['css_'] = ace.Mode.CSS;


### PR DESCRIPTION
TBR. Strangely, the default association appears to be missing in Ace.
