### PR TITLE
Hide .hg folder

### DIFF
--- a/ide/web/lib/workspace.dart
+++ b/ide/web/lib/workspace.dart
@@ -977,7 +977,7 @@ class Folder extends Container {
 
   // TODO(keertip): remove check for 'cache'
   bool isScmPrivate() => name == '.git' || name == '.svn' || name == '.pub'
-      || name =='cache';
+      || name =='cache' || name == '.hg';
 
   bool isDerived() {
     // TODO(devoncarew): 'cache' is a temporay folder - it will be removed.


### PR DESCRIPTION
I noticed you're already hiding `.git` folders, so think it makes sense to hide `.hg` too. Although you don't have Mercurial support, some of us use CDE against folders that are in Mercurial, so I believe it makes sense to hide them too.
