### PR TITLE
paper button template updated with raised

### DIFF
--- a/ide/web/lib/templates/web/web_app_polymer_js/index.html_
+++ b/ide/web/lib/templates/web/web_app_polymer_js/index.html_
@@ -57,7 +57,7 @@
 
   <section>
     <template id="toastGroup" is="auto-binding">
-      <paper-button raisedButton right label="Show Toast" on-click="{{showToast}}">
+      <paper-button raised right label="Show Toast" on-click="{{showToast}}">
       </paper-button>
       <paper-toast id="toast" text="Sample toast here."></paper-toast>
     </template>


### PR DESCRIPTION
Polymer 0.4.2 introduced breaking changes to <paper-button>; the raisedButton attribute has been changed to raised.  As it is, generated web apps will not properly display the button.

Label is also deprecated, to wit: "label attribute is now deprecated. The new usage is to put the label in light DOM."

The raisedButton => raised attribute change also needs to be propagated through the rest of the templates as well, i.e., the chrome app polymer template, etc.
