### PR TITLE
Disable git-salt completely.

### DIFF
--- a/ide/web/lib/spark_flags.dart
+++ b/ide/web/lib/spark_flags.dart
@@ -49,8 +49,8 @@ class SparkFlags {
   // Git:
   static bool get gitPull =>
       _flags['enable-git-pull'] == true;
-  static bool get gitSalt =>
-      _flags['enable-git-salt'] == true;
+  static bool get gitSalt => false;
+      //_flags['enable-git-salt'] == true;
 
   static bool get polymerDesigner =>
       _flags['enable-polymer-designer'] == true;

--- a/ide/web/spark_polymer.html
+++ b/ide/web/spark_polymer.html
@@ -150,7 +150,6 @@
 
   <script type="application/javascript" src="third_party/uuid.js/uuid.js"></script>
   <script type="application/javascript" src="lib/mobile/android_rsa.js"></script>
-  <script type="application/javascript" src="lib/git_salt/git_salt.js"></script>
   <script type="application/javascript" src="third_party/wam/wam_fs.concat.js"></script>
   <script type="application/javascript" src="lib/wam/wamfs.js"></script>
 


### PR DESCRIPTION
@ussuri  This removes the git_salt.js file and makes the `git-salt` flag return false always. There is no entry point for the module to load now.
#3621
