### PR TITLE
[Polymer Designer] A workaround to fix the disappearing elements palette

### DIFF
--- a/cde-polymer-designer.dart/lib/cde_polymer_designer.js
+++ b/cde-polymer-designer.dart/lib/cde_polymer_designer.js
@@ -222,31 +222,31 @@ Polymer('cde-polymer-designer', {
     // TODO(ussuri): Some of this will become unnecessary once BUG #3467 is
     // resolved.
     this.insertCssIntoWebview_(
-        /* Reduce the initial font sizes */
+        // Reduce the initial font sizes.
         "#designer /deep/ *," +
         "#designer /deep/ #tabs > * {" +
         "  font-size: 13px;" +
         "}" +
-        /* Adjust tabs' height and color */
+        // Adjust tabs' height and color.
         "#designer /deep/ #inspector::shadow > #tabs," +
         "#designer /deep/ .paletteTree > #tabs {" +
         "  padding-top: 0;" +
         "  padding-bottom: 0;" +
         "  background-color: #fafafa;" +
         "}" +
-        /* Skinnier splitter */
+        // Skinnier splitter.
         "#designer /deep/ core-splitter {" +
         "  height: 8px;" +
         "  background-color: #fafafa;" +
         "}" +
-        /* Adjust toolbars' height */
+        // Adjust toolbars' height.
         "#designer /deep/ core-toolbar," +
         "#designer /deep/ #topBar," +
         "#designer /deep/ .designTools {" +
         "  height: 50px;" +
         "  background-color: #fafafa;" +
         "}" +
-        /* Make buttons' smaller and round */
+        // Make buttons' smaller and round.
         "#designer /deep/ core-icon-button {" +
         "  height: 38px;" +
         "  width: 38px;" +
@@ -256,7 +256,7 @@ Polymer('cde-polymer-designer', {
         "#designer /deep/ core-icon-button:hover {" +
         "  background-color: #eee;" +
         "}" +
-        /* Hide some UI elements we do not need */
+        // Hide some UI elements we do not need.
         "#designer::shadow > #appbar > * {" +
         "  display: none;" +
         "}" +
@@ -266,15 +266,21 @@ Polymer('cde-polymer-designer', {
         "#designer::shadow > #appbar > .design-controls > .separator:first-child {" +
         "  display: none;" +
         "}" +
-        /* Revert font size for the current element */
+        // Revert font size for the current element.
         "#designer /deep/ #selectedElement {" +
         "  font-size: 15px;" +
         "}" +
-        /* Adjust palette elements' style */
+        // Adjust palette elements' style.
         "#designer /deep/ .simple-item {" +
         "  height: 30px;" +
         "  line-height: 30px;" +
         "  font-size: 13px;" +
+        "}" +
+        // Override palette's opacity from 0.9. This is an empirically found
+        // way to mask BUG #3634.
+        // TODO(ussuri): This is possibly related to BUG #3466.
+        "#designer /deep/ #palette::shadow #list {" +
+        "  opacity: 1;" +
         "}"
     );
   },


### PR DESCRIPTION
TBR

Fixes #3634 (or rather patches it).

There is some issue probably with WebKit or `<webview>` failing to render stacking contexts when the CSS is changing or something like that. The palette's opacity was set to 0.9, and that somehow caused it to disappear (actually, just fail to render) when any category was expanded with a mouse click. Setting opacity to 1 (and thus eliminating a stacking context) somehow fixed it.

There is already [a somewhat related place](https://github.com/dart-lang/chromedeveditor/blob/master/cde-polymer-designer.dart/lib/cde_polymer_designer.js#L203) in `cde-polymer-designer.dart`.
