### PR TITLE
Disable build dartium

### DIFF
--- a/ide/tool/drone_io.sh
+++ b/ide/tool/drone_io.sh
@@ -34,9 +34,9 @@ fi
 set -e
 
 # Run tests the Dart version of the app.
-if [ "$HAS_DARTIUM" = "true" ]; then
-  #dart tool/test_runner.dart --dartium
-fi
+#if [ "$HAS_DARTIUM" = "true" ]; then
+#  dart tool/test_runner.dart --dartium
+#fi
 
 # Run tests on the dart2js version of the app.
 if [ "$DRONE" = "true" ]; then


### PR DESCRIPTION
@ussuri  Since the build is always failing on dartium and we know the reason why, We should disable it until we fix it.
