### PR TITLE
Fix: paper-fab fill color was incorrectly set in cde-fab

### DIFF
--- a/ide/web/lib/ui/cde-fab/cde-fab.css
+++ b/ide/web/lib/ui/cde-fab/cde-fab.css
@@ -2,7 +2,7 @@
 /* All rights reserved.  Use of this source code is governed by a BSD-style */
 /* license that can be found in the LICENSE file. */
 
-:host {
+paper-fab {
   fill: #fff;
   color: #fff;
 }


### PR DESCRIPTION
FYI @devoncarew

Follow-up to #3514. This had no visible effect because the chosen color coincided with the default.
