### PR TITLE
Use workaround to enable socket features used by git-salt, used by Bower

### DIFF
--- a/ide/web/manifest.json
+++ b/ide/web/manifest.json
@@ -29,9 +29,9 @@
   "permissions": [
     "http://*/*",
     "https://*/*",
-    "identity",
     "clipboardRead",
     "clipboardWrite",
+    "contextMenus",
     "developerPrivate",
     {
       "fileSystem": [
@@ -40,13 +40,19 @@
         "directory"
       ]
     },
+    "identity",
     "management",
     "nativeMessaging",
+    {
+      "socket": [
+        "tcp-connect",
+        "resolve-host"
+      ]
+    },
+    "storage",
     "syncFileSystem",
     "system.network",
-    "storage",
     "unlimitedStorage",
-    "contextMenus",
     "usb",
     {
       "usbDevices": [


### PR DESCRIPTION
@gaurave 
