### PR TITLE
Fix deploy compile warning

### DIFF
--- a/ide/web/lib/ui/cde-fab/cde-fab.html
+++ b/ide/web/lib/ui/cde-fab/cde-fab.html
@@ -1,6 +1,10 @@
+<!DOCTYPE html>
+
 <!-- Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
      All rights reserved. Use of this source code is governed by a BSD-style
      license that can be found in the LICENSE file. -->
+
+<link rel="import" href="../../../packages/polymer/polymer.html">
 
 <link rel="import" href="../../../packages/paper/core-icons/core-icons.html">
 <link rel="import" href="../../../packages/paper/paper-fab/paper-fab.html">


### PR DESCRIPTION
Fix below warnings.
@ussuri 

warning line 8, column 1 of web/lib/ui/cde-fab/cde-fab.html: Missing definition for <polymer-element>, please add the following HTML import at the top of this file: <li
nk rel="import" href="../../../packages/polymer/polymer.html">. See http://goo.gl/5HPeuP#polymer_3 for details.
 warning line 3, column 56 of web/lib/ui/cde-fab/cde-fab.html: (from html5lib) Unexpected start tag (html). Expected DOCTYPE. See http://goo.gl/5HPeuP#polymer_40 for details.
