### PR TITLE
Pin Polymer version in templates to `latest`

### DIFF
--- a/ide/web/lib/templates/chrome/chrome_app_polymer_js/bower.json_
+++ b/ide/web/lib/templates/chrome/chrome_app_polymer_js/bower.json_
@@ -7,7 +7,7 @@
   "author": "",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#master",
-    "paper-elements": "Polymer/paper-elements#master"
+    "polymer": "Polymer/polymer#latest",
+    "paper-elements": "Polymer/paper-elements#latest"
   }
 }

--- a/ide/web/lib/templates/polymer/polymer_element_js/bower.json_
+++ b/ide/web/lib/templates/polymer/polymer_element_js/bower.json_
@@ -2,6 +2,6 @@
   "name": "``projectName``",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#master"
+    "polymer": "Polymer/polymer#latest"
   }
 }

--- a/ide/web/lib/templates/web/web_app_polymer_js/bower.json_
+++ b/ide/web/lib/templates/web/web_app_polymer_js/bower.json_
@@ -7,7 +7,7 @@
   "author": "",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#master",
-    "paper-elements": "Polymer/paper-elements#master"
+    "polymer": "Polymer/polymer#latest",
+    "paper-elements": "Polymer/paper-elements#latest"
   }
 }


### PR DESCRIPTION
...now that the GitHub access rate limit is no longer an issue, which was the reason for the original back-and-forth between master-latest-master (master doesn't go through the version/tag resolution, so it didn't hit the limit, which was used as a quick workaround). The rate limit issue was fixed in #3733 by switching to `git ls-remote` instead of using the GitHub API.

TBR: @gaurave
