### PR TITLE
Rearrange rules in spark_polymer_ui.css by UI area

### DIFF
--- a/cde-polymer-designer.dart/lib/cde_polymer_designer.js
+++ b/cde-polymer-designer.dart/lib/cde_polymer_designer.js
@@ -19,11 +19,11 @@ PromiseCompleter.prototype.reject = function(value) {
 
 PromiseCompleter.prototype.then = function(onFulfilled, onRejected) {
   this.promise.then(onFulfilled, onRejected);
-}
+};
 
 PromiseCompleter.prototype.catch = function(onRejected) {
   this.promise.catch(onRejected);
-}
+};
 
 Polymer('cde-polymer-designer', {
   // NOTE: Make sure this is in-sync with ide/web/manifest.json.
@@ -117,7 +117,7 @@ Polymer('cde-polymer-designer', {
    * @return: void
    */
   unload: function() {
-    if (this.webview_ != null) {
+    if (this.webview_ !== null) {
       this.webview_.terminate();
       this.shadowRoot.removeChild(this.webview_);
     }
@@ -352,7 +352,7 @@ Polymer('cde-polymer-designer', {
           break;
         case 'revert_code':
           designer.loadHtml(initialCode);
-          breal;
+          break;
         default:
           throw "Unsupported request from client";
       }
@@ -397,7 +397,7 @@ Polymer('cde-polymer-designer', {
   },
 
   /**
-   * Executes a script in [webview_]'s "isolated world", which give the script
+   * Executes a script in [webview_]'s "isolated world", which gives the script
    * access only to the webview's DOM, but not the JS context.
    *
    * @return: Promise<array of any>

--- a/ide/web/spark_polymer_ui.dart
+++ b/ide/web/spark_polymer_ui.dart
@@ -91,22 +91,22 @@ class SparkPolymerUI extends SparkWidget {
    * where the dynamically created Ace container, which needs them, lives.
    */
   void _poachAceStyles(List<Node> nodes) {
-    final List<Element> aceNodes = [];
+    final List<StyleElement> aceStyles = [];
     for (Node node in nodes) {
       if (node is StyleElement &&
-          (node.id.startsWith('ace') || node.innerHtml.contains('ace_')) {
-        aceNodes.add(node);
+          (node.id.startsWith('ace') || node.innerHtml.contains('ace_'))) {
+        aceStyles.add(node);
       }
     }
-    for (Node node in aceNodes) {
+    for (StyleElement style in aceStyles) {
       // When Ace thinks it needs to reuse the same style at some point (e.g.
       // previously used theme is selected again), it justs check in the <head>
       // by node id, so, since we move the originals, it will try to insert
       // duplicates: skip moving those here (but remove them from DOM).
-      node.remove();
-      final String id = node.id;
+      style.remove();
+      final String id = style.id;
       if (id != null && id.isNotEmpty && !_poachedAceNodes.add(id)) continue;
-      shadowRoot.append(node);
+      shadowRoot.append(style);
     }
   }
 


### PR DESCRIPTION
@umop, @gaurave

We've accumulated quite some technical debt around our top-level sources. This is one small step to gradually fix that. I'm simply rearranging the rules here, no real changes. I think I will further split this `.css` into smaller chunks in a follow-up.
