### PR TITLE
Undo fix for garbled tree view on file switch: root cause seems gone

### DIFF
--- a/ide/web/lib/ui/widgets/listview.dart
+++ b/ide/web/lib/ui/widgets/listview.dart
@@ -11,7 +11,6 @@ library spark.ui.widgets.listview;
 import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
-import 'dart:math' as math;
 
 import 'listview_cell.dart';
 import 'listview_row.dart';
@@ -249,11 +248,8 @@ class ListView {
    * This method adds in the DOM the visible cells.
    */
   void _showVisible() {
-    // BUG #3084.
-    const int slop = 100;
-
-    int scopeTop = math.max(_container.scrollTop - slop, 0);
-    int scopeBottom = _container.scrollTop + _container.offsetHeight + slop;
+    int scopeTop = _container.scrollTop;
+    int scopeBottom = _container.scrollTop + _container.offsetHeight;
 
     if (_rows.length == 0) {
       return;


### PR DESCRIPTION
TBR: @devoncarew 

The original problem is described in #3084; a fix was committed in #3092. I've tried to reproduce now with that fix undone, and everything seems to be working fine. Let's speculatively commit this and see what happens.
