### PR TITLE
Preference file wired up behind flag

### DIFF
--- a/ide/web/app.json
+++ b/ide/web/app.json
@@ -1,0 +1,4 @@
+{
+  "test-mode":true,
+  "enable-editor-config": true
+}

--- a/ide/web/app.json
+++ b/ide/web/app.json
@@ -1,4 +1,0 @@
-{
-  "test-mode":true,
-  "enable-editor-config": true
-}

--- a/ide/web/lib/spark_flags.dart
+++ b/ide/web/lib/spark_flags.dart
@@ -81,6 +81,10 @@ class SparkFlags {
   static bool get enableNewUsbApi =>
       _flags['enable-new-usb-api'] == true && PlatformInfo.chromeVersion >= 40;
 
+  // TODO(ericarnold): Remove once editorconfig is complete
+  static bool get enableEditorConfig =>
+      _flags['enable-editor-config'] == true;
+
   /**
    * Add new flags to the set, possibly overwriting the existing values.
    * Maps are treated specially, updating the top-level map entries rather

--- a/ide/web/spark.dart
+++ b/ide/web/spark.dart
@@ -509,6 +509,7 @@ abstract class Spark
     actionManager.registerAction(new PrevMarkerAction(this));
     // TODO(devoncarew): TODO(devoncarew): Removed as per #2348.
     //actionManager.registerAction(new FileOpenAction(this));
+    actionManager.registerAction(new GlobalSettingsAction(this));
     actionManager.registerAction(new FileNewAction(this,
         getDialogElement('#fileNewDialog')));
     actionManager.registerAction(new FolderNewAction(this,
@@ -1444,6 +1445,21 @@ class FileOpenAction extends SparkAction {
 
   void _invoke([Object context]) {
     spark.openFile();
+  }
+}
+
+class GlobalSettingsAction extends SparkAction {
+  PreferenceFile _file;
+
+  GlobalSettingsAction(Spark spark) : super(spark, "global-settings", "Settings…") {
+  }
+
+  void _invoke([Object context]) {
+    if (_file == null) {
+      _file = new PreferenceFile(spark.prefs.prefsStore, 'user.editorconfig');
+    }
+
+    spark.openEditor(_file);
   }
 }
 

--- a/ide/web/spark_polymer.dart
+++ b/ide/web/spark_polymer.dart
@@ -248,7 +248,8 @@ class SparkPolymer extends Spark {
     _bindButtonToAction('runButton', 'application-run');
     _bindButtonToAction('leftNav', 'navigate-back');
     _bindButtonToAction('rightNav', 'navigate-forward');
-    _bindButtonToAction('settingsButton', 'settings');
+    _bindButtonToAction('settingsButton',
+        SparkFlags.enableEditorConfig ? 'global-settings' : 'settings');
   }
 
   //


### PR DESCRIPTION
Preference based file implementation to tie into editorconfig (through settings button). Hidden behind enable-editor-config flag.

@gaurave Please review.  This wires in the .editorconfig work into an editor for iteration in the real world.  I'm implementing `File` to do this (thanks to @devoncarew for the help there).

Contributes to #3436
