### PR TITLE
Fixes + normalization in Chrome app templates' manifests

### DIFF
--- a/ide/web/lib/templates/chrome/chrome_app_dart/web/manifest.json_
+++ b/ide/web/lib/templates/chrome/chrome_app_dart/web/manifest.json_
@@ -2,9 +2,9 @@
   "manifest_version": 2,
   "name": "``projectName``",
   "short_name": "``projectName``",
-  "description": "Description for ``projectName``",
-
-  "version": "0.0.1.0",
+  "description": "",
+  "version": "0.0.1",
+  "minimum_chrome_version": "38",
 
   "icons": {
     "16": "icon_16.png",

--- a/ide/web/lib/templates/chrome/chrome_app_js/manifest.json_
+++ b/ide/web/lib/templates/chrome/chrome_app_js/manifest.json_
@@ -2,9 +2,9 @@
   "manifest_version": 2,
   "name": "``projectName``",
   "short_name": "``projectName``",
-  "description": "Description for ``projectName``",
-
-  "version": "0.0.1.0",
+  "description": "",
+  "version": "0.0.1",
+  "minimum_chrome_version": "38",
 
   "icons": {
     "16": "assets/icon_16.png",

--- a/ide/web/lib/templates/chrome/chrome_app_polymer_js/manifest.json_
+++ b/ide/web/lib/templates/chrome/chrome_app_polymer_js/manifest.json_
@@ -1,13 +1,16 @@
 {
   "manifest_version": 2,
   "name": "``projectName``",
+  "short_name": "``projectName``",
   "description": "",
   "version": "0.0.1",
-  "minimum_chrome_version": "23",
+  "minimum_chrome_version": "38",
+
   "icons": {
     "16": "assets/icon_16.png",
     "128": "assets/icon_128.png"
   },
+
   "app": {
     "background": {
       "scripts": ["background.js"]

--- a/ide/web/lib/templates/chrome/chrome_extension_js/manifest.json_
+++ b/ide/web/lib/templates/chrome/chrome_extension_js/manifest.json_
@@ -1,9 +1,11 @@
 {
   "manifest_version": 2,
   "name": "``projectName``",
+  "short_name": "``projectName``",
   "description": "",
   "version": "0.0.1",
-  "minimum_chrome_version": "23",
+  "minimum_chrome_version": "38",
+
   "icons": {
     "16": "assets/icon_16.png",
     "128": "assets/icon_128.png"


### PR DESCRIPTION
TBR: @umop 

Fix + normalize some typos and omissions in manifest.json of Chrome app templates, and bump minimum required Chrome version to 38.
