### PR TITLE
Added `.bower-git` to isScmPrivate + removed outdated `cache`

### DIFF
--- a/ide/web/lib/workspace.dart
+++ b/ide/web/lib/workspace.dart
@@ -984,13 +984,14 @@ class Folder extends Container {
       });
   }
 
-  // TODO(keertip): remove check for 'cache'
-  bool isScmPrivate() => name == '.git' || name == '.svn' || name == '.pub'
-      || name =='cache' || name == '.hg';
+  static const List<String> _PRIVATE_SCM_FOLDERS = const [
+      '.git', '.bower-git', '.pub', '.svn', '.hg'
+  ];
+
+  bool isScmPrivate() => _PRIVATE_SCM_FOLDERS.contains(name);
 
   bool isDerived() {
-    // TODO(devoncarew): 'cache' is a temporay folder - it will be removed.
-    if ((name == 'build' || name == 'cache') && parent is Project) {
+    if (name == 'build' && parent is Project) {
       return true;
     } else {
       return super.isDerived();


### PR DESCRIPTION
TBR @gaurave 

It's a minimal fix to make `workspace.isScmPrivate` ignore the recently added `.bower-git`. A more thorough fix should aggregate all SCM-related names as a set of constants in `scm.dart` (or similar) and use them consistently everywhere.
