### PR TITLE
Concentrate knowledge/handling of what Pub can/can't support in Pub itself

### DIFF
--- a/ide/web/lib/package_mgmt/package_manager.dart
+++ b/ide/web/lib/package_mgmt/package_manager.dart
@@ -60,7 +60,7 @@ abstract class PackageServiceProperties {
       packageRefPrefixRegexp.matchAsPrefix(url) != null;
 
   bool isSecondaryPackage(Resource resource) {
-    return resource.path.contains('/$getPackagesDirName/') &&
+    return resource.path.contains('/' + getPackagesDirName(resource) + '/') &&
            !isInPackagesFolder(resource);
   }
 

--- a/ide/web/lib/package_mgmt/pub.dart
+++ b/ide/web/lib/package_mgmt/pub.dart
@@ -125,7 +125,11 @@ class PubManager extends PackageManager {
       bool isUpgrade,
       ProgressMonitor monitor) {
     // Don't run pub on Windows (#2743).
-    if (PlatformInfo.isWin) return new Future.value();
+    if (PlatformInfo.isWin) {
+      throw new SparkException(
+          SparkErrorMessages.PUB_ON_WINDOWS_MSG,
+          errorCode: SparkErrorConstants.PUB_ON_WINDOWS_NOT_SUPPORTED);
+    }
 
     // Fake the total amount of work, since we don't know it. When an update
     // comes from Tavern, just refresh the generic message w/o showing progress.

--- a/ide/web/spark.dart
+++ b/ide/web/spark.dart
@@ -1858,14 +1858,8 @@ abstract class PackageManagementAction
       super(spark, id, name);
 
   void _invoke([context]) {
-    if (!_canRunAction()) {
-      return;
-    }
-    ws.Resource resource;
-
     // NOTE: [appliesTo] ensures this is always valid.
-    resource = context.single;
-      
+    final ws.Resource resource = context.single;
     // [appliesTo] uses [isPackageResource], which guarantees that the below
     // will return a non-null.
     final ws.Folder folder =
@@ -1885,21 +1879,10 @@ abstract class PackageManagementAction
   PackageServiceProperties get _serviceProperties;
 
   Job _createJob(ws.Container container);
-
-  bool _canRunAction() => true;
 }
 
 abstract class PubAction extends PackageManagementAction {
   PubAction(Spark spark, String id, String name) : super(spark, id, name);
-
-  bool _canRunAction() {
-    if (PlatformInfo.isWin) {
-      throw new SparkException(
-          SparkErrorMessages.PUB_ON_WINDOWS_MSG,
-          errorCode: SparkErrorConstants.PUB_ON_WINDOWS_NOT_SUPPORTED);
-    }
-    return true;
-  }
 
   PackageServiceProperties get _serviceProperties =>
       spark.pubManager.properties;
@@ -1952,7 +1935,7 @@ class CspFixAction extends SparkAction implements ContextAction {
     });
   }
 
-  String get category => 'refactor';
+  String get category => 'source_manipulation';
 
   bool appliesTo(List list) => CspFixer.mightProcess(list);
 }


### PR DESCRIPTION
@gaurave 
- Move throwing "Pub can't run on Windows" from PackageManagementAction to Pub, where another similar exception is already thrown.
- Also, fix an accidentally discovered bug in PackageServiceProperties.isSecondaryPackageResource().
