### PR TITLE
patch for dom serializer to emit bower_components as directory base for imports

### DIFF
--- a/cde-polymer-designer.dart/lib/src/polymer_designer/elements/dom-serializer/dom-serializer.html
+++ b/cde-polymer-designer.dart/lib/src/polymer_designer/elements/dom-serializer/dom-serializer.html
@@ -293,10 +293,11 @@ Polymer({
       }
     }
     // ensure we at least import polymer
+    // TODO: this imports polymer iff the imports are empty; but shouldn't we always import polymer, for every custom element?
     if (!imports.length) {
       var p = element.ownerDocument.createElement('link');
       p.rel = 'import';
-      p.setAttribute('href', '../polymer/polymer.html');
+      p.setAttribute('href', 'bower_components/polymer/polymer.html');
       imports.push(p);
     }
     return imports;
@@ -309,7 +310,7 @@ Polymer({
       var imports = c.querySelectorAll('link[rel=import]').array();
       for (var i=0, l=imports.length, p, h; (i<l) && (p=imports[i]); i++) {
         // make serializable href
-        h = p.getAttribute('href').replace('components', '..');
+        h = p.getAttribute('href').replace('..', 'bower_components');
         p.setAttribute('href', h);
       }
       return imports;


### PR DESCRIPTION
patched cde_polymer_designer to emit `bower_components` instead of `..` for imports' base directory; added potential todo wrt to importing polymer for every custom element, instead of current behavior which imports iff the imports list is empty.

rational for patch: whenever I use PD I always have to replace the .. base directory with bower_components, (assuming the custom element resides in the top directory).  Since polymer documentation recommends obtaining polymer using bower with something like `bower install Polymer/polymer` in the base directory, it seems safe to assume polymer will be in a bower_components directory in the top of the project, and hence the use for renaming the base directory for emitted components.