### PR TITLE
various cleanups and fixes

### DIFF
--- a/ide/.analysis_options
+++ b/ide/.analysis_options
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - build/**

--- a/ide/.gitignore
+++ b/ide/.gitignore
@@ -10,4 +10,5 @@ build/
 dist/
 docs/
 packages
+.packages
 cache/

--- a/ide/tool/grind.dart
+++ b/ide/tool/grind.dart
@@ -312,7 +312,7 @@ void _zip(GrinderContext context, String dirToZip, String destFile) {
           arguments: ['a', '-r', destPath, '.'],
           workingDirectory: dirToZip,
           quiet: true);
-    } on ProcessException catch(e) {
+    } on ProcessException {
       context.fail("Unable to execute 7z.\n"
         "Please install 7zip. Add 7z directory to the PATH environment variable.");
     }
@@ -394,20 +394,20 @@ String _getRepositoryUrl() {
   return _getCommandOutput('git config remote.origin.url');
 }
 
-// Returns the current revision identifier of the local copy.
-String _getCurrentRevision() {
-  return _getCommandOutput('git rev-parse HEAD').substring(0, 10);
-}
+// // Returns the current revision identifier of the local copy.
+// String _getCurrentRevision() {
+//   return _getCommandOutput('git rev-parse HEAD').substring(0, 10);
+// }
 
-// In case, release is performed on a non-releasable branch/repository, we just
-// archive and name the archive with the revision identifier.
-void _archiveWithRevision(GrinderContext context) {
-  context.log('Performing archive instead.');
-  String version = _getCurrentRevision();
-  String filename = 'spark-rev-${version}.zip';
-  archive(context, filename);
-  context.log("Created ${filename}");
-}
+// // In case, release is performed on a non-releasable branch/repository, we just
+// // archive and name the archive with the revision identifier.
+// void _archiveWithRevision(GrinderContext context) {
+//   context.log('Performing archive instead.');
+//   String version = _getCurrentRevision();
+//   String filename = 'spark-rev-${version}.zip';
+//   archive(context, filename);
+//   context.log("Created ${filename}");
+// }
 
 String _modifyManifestWithDroneIOBuildNumber(GrinderContext context,
                                              Map<String, String> channelConfig)
@@ -464,15 +464,15 @@ void _modifyLocaleWithChannelConfig(GrinderContext context,
       joinDir(BUILD_DIR, ['web', '_locales', 'en']));
 }
 
-void _removePackagesLinks(GrinderContext context, Directory target) {
-  target.listSync(recursive: true, followLinks: false).forEach((FileSystemEntity entity) {
-    if (entity is Link && fileName(entity) == 'packages') {
-      try { entity.deleteSync(); } catch (_) { }
-    } else if (entity is Directory) {
-      _removePackagesLinks(context, entity);
-    }
-  });
-}
+// void _removePackagesLinks(GrinderContext context, Directory target) {
+//   target.listSync(recursive: true, followLinks: false).forEach((FileSystemEntity entity) {
+//     if (entity is Link && fileName(entity) == 'packages') {
+//       try { entity.deleteSync(); } catch (_) { }
+//     } else if (entity is Directory) {
+//       _removePackagesLinks(context, entity);
+//     }
+//   });
+// }
 
 /**
  * Create an archived version of the Dart SDK.
@@ -536,23 +536,23 @@ void _delete(String path, [GrinderContext context]) {
   }
 }
 
-void _rename(String srcPath, String destPath, [GrinderContext context]) {
-   if (context != null) {
-     context.log('rename ${srcPath} to ${destPath}');
-   }
-   File srcFile = new File(srcPath);
-   srcFile.renameSync(destPath);
-}
+// void _rename(String srcPath, String destPath, [GrinderContext context]) {
+//    if (context != null) {
+//      context.log('rename ${srcPath} to ${destPath}');
+//    }
+//    File srcFile = new File(srcPath);
+//    srcFile.renameSync(destPath);
+// }
 
-void _copyFileWithNewName(File srcFile, Directory destDir, String destFileName,
-                          [GrinderContext context]) {
-  File destFile = joinFile(destDir, [destFileName]);
-  if (context != null) {
-    context.log('copying ${srcFile.path} to ${destFile.path}');
-  }
-  destDir.createSync(recursive: true);
-  destFile.writeAsBytesSync(srcFile.readAsBytesSync());
-}
+// void _copyFileWithNewName(File srcFile, Directory destDir, String destFileName,
+//                           [GrinderContext context]) {
+//   File destFile = joinFile(destDir, [destFileName]);
+//   if (context != null) {
+//     context.log('copying ${srcFile.path} to ${destFile.path}');
+//   }
+//   destDir.createSync(recursive: true);
+//   destFile.writeAsBytesSync(srcFile.readAsBytesSync());
+// }
 
 void _runCommandSync(GrinderContext context, String command, {String cwd}) {
   context.log(command);

--- a/ide/web/lib/ace.dart
+++ b/ide/web/lib/ace.dart
@@ -14,7 +14,7 @@ import 'dart:math' as math;
 
 import 'package:ace/ace.dart' as ace;
 import 'package:ace/proxy.dart';
-import 'package:crypto/crypto.dart' as crypto;
+//import 'package:crypto/crypto.dart' as crypto;
 import 'package:crc32/crc32.dart' as crc;
 
 import 'css/cssbeautify.dart';
@@ -726,8 +726,8 @@ class AceManager {
       _linkingMarkerId = null;
     }
 
-    html.DivElement contentElement =
-        _aceEditor.renderer.containerElement.querySelector(".ace_content");
+    // html.DivElement contentElement =
+    //     _aceEditor.renderer.containerElement.querySelector(".ace_content");
 
     if (markerRange != null) {
       _markerSession = currentSession;
@@ -830,7 +830,7 @@ class AceManager {
       // Only add errors and warnings to the mini-map.
       if (marker.severity >= workspace.Marker.SEVERITY_WARNING) {
         html.Element minimapMarker = new html.Element.div();
-        minimapMarker.classes.add("minimap-marker ${marker.severityDescription}");
+        minimapMarker.classes.addAll(['minimap-marker', marker.severityDescription]);
         minimapMarker.style.top = markerPos;
         minimapMarker.onClick.listen((e) => _miniMapMarkerClicked(e, marker));
 
@@ -1209,11 +1209,11 @@ abstract class AceManagerDelegate {
   void openEditor(workspace.File file, {Span selection});
 }
 
-String _calcMD5(String text) {
-  crypto.MD5 md5 = new crypto.MD5();
-  md5.add(text.codeUnits);
-  return crypto.CryptoUtils.bytesToHex(md5.close());
-}
+// String _calcMD5(String text) {
+//   crypto.MD5 md5 = new crypto.MD5();
+//   md5.add(text.codeUnits);
+//   return crypto.CryptoUtils.bytesToHex(md5.close());
+// }
 
 /**
  * Given some arbitrary text and an offset into it, attempt to return the

--- a/ide/web/lib/actions.dart
+++ b/ide/web/lib/actions.dart
@@ -423,10 +423,10 @@ abstract class ContextAction extends Action {
   bool appliesTo(Object object);
 }
 
-String _toTitleCase(String str) {
-  if (str.length < 2) {
-    return str.toUpperCase();
-  } else {
-    return '${str[0].toUpperCase()}${str.substring(1).toLowerCase()}';
-  }
-}
+// String _toTitleCase(String str) {
+//   if (str.length < 2) {
+//     return str.toUpperCase();
+//   } else {
+//     return '${str[0].toUpperCase()}${str.substring(1).toLowerCase()}';
+//   }
+// }

--- a/ide/web/lib/app.dart
+++ b/ide/web/lib/app.dart
@@ -8,6 +8,7 @@
 library spark.app;
 
 import 'dart:async';
+import 'dart:core' hide Resource;
 
 import 'workspace.dart';
 

--- a/ide/web/lib/apps/app_manifest_builder.dart
+++ b/ide/web/lib/apps/app_manifest_builder.dart
@@ -96,7 +96,7 @@ class AppManifestBuilder extends Builder {
           JsonParser parser = new JsonParser(contents, listener);
           parser.parse();
         }
-      } on FormatException catch (e) {
+      } on FormatException {
         // Ignore e; already reported through the listener interface.
       }
     });

--- a/ide/web/lib/apps/app_utils.dart
+++ b/ide/web/lib/apps/app_utils.dart
@@ -4,6 +4,8 @@
 
 library spark.app_utils;
 
+import 'dart:core' hide Resource;
+
 import '../workspace.dart';
 
 /**

--- a/ide/web/lib/builder.dart
+++ b/ide/web/lib/builder.dart
@@ -9,6 +9,7 @@
 library spark.builder;
 
 import 'dart:async';
+import 'dart:core' hide Resource;
 
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';

--- a/ide/web/lib/developer_private.dart
+++ b/ide/web/lib/developer_private.dart
@@ -512,7 +512,7 @@ class EventData extends ChromeObject {
 ItemInfo _createItemInfo(JsObject jsProxy) => jsProxy == null ? null : new ItemInfo.fromProxy(jsProxy);
 PackDirectoryResponse _createPackDirectoryResponse(JsObject jsProxy) => jsProxy == null ? null : new PackDirectoryResponse.fromProxy(jsProxy);
 //any _createany(JsObject jsProxy) => jsProxy == null ? null : new any.fromProxy(jsProxy);
-EventData _createEventData(JsObject jsProxy) => jsProxy == null ? null : new EventData.fromProxy(jsProxy);
+//EventData _createEventData(JsObject jsProxy) => jsProxy == null ? null : new EventData.fromProxy(jsProxy);
 ItemType _createItemType(String value) => ItemType.VALUES.singleWhere((ChromeEnum e) => e.value == value);
 InstallWarning _createInstallWarning(JsObject jsProxy) => jsProxy == null ? null : new InstallWarning.fromProxy(jsProxy);
 ItemInspectView _createItemInspectView(JsObject jsProxy) => jsProxy == null ? null : new ItemInspectView.fromProxy(jsProxy);

--- a/ide/web/lib/editor_area.dart
+++ b/ide/web/lib/editor_area.dart
@@ -9,6 +9,7 @@
 library spark.editor_area;
 
 import 'dart:async';
+import 'dart:core' hide Resource;
 import 'dart:html' hide File;
 
 import 'editors.dart';

--- a/ide/web/lib/editors.dart
+++ b/ide/web/lib/editors.dart
@@ -10,6 +10,7 @@ library spark.editors;
 
 import 'dart:async';
 import 'dart:convert' show JSON;
+import 'dart:core' hide Resource;
 import 'dart:html' as html;
 
 import 'ace.dart' as ace;
@@ -546,4 +547,3 @@ class PreferenceContentProvider implements ContentProvider {
 
   Future write(String content) => _store.setValue(_filename, content);
 }
-

--- a/ide/web/lib/git/commands/branch.dart
+++ b/ide/web/lib/git/commands/branch.dart
@@ -33,7 +33,6 @@ class Branch {
   static final branchRegex = new RegExp(BRANCH_PATTERN);
 
   static bool _verifyBranchName(String name) {
-    int length = name.length;
     return (name.isNotEmpty && branchRegex.matchAsPrefix(name) != null &&
         !name.endsWith('.') && !name.endsWith('.lock') && !name.endsWith('/'));
   }

--- a/ide/web/lib/launch.dart
+++ b/ide/web/lib/launch.dart
@@ -9,6 +9,7 @@ library spark.launch;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:core' hide Resource;
 import 'dart:html' show window;
 
 import 'package:chrome/chrome_app.dart' as chrome;

--- a/ide/web/lib/outline.dart
+++ b/ide/web/lib/outline.dart
@@ -300,7 +300,12 @@ abstract class OutlineItem {
       _element.append(_typeSpan);
     }
 
-    _element.classes.add("outlineItem ${cssClassName}");
+    _element.classes.add('outlineItem');
+    if (cssClassName.contains(' ')) {
+      _element.classes.addAll(cssClassName.split(' '));
+    } else {
+      _element.classes.add(cssClassName);
+    }
   }
 
   String get displayName => _data.name;

--- a/ide/web/lib/package_mgmt/bower.dart
+++ b/ide/web/lib/package_mgmt/bower.dart
@@ -11,6 +11,7 @@ library spark.package_mgmt.bower;
 
 import 'dart:async';
 import 'dart:convert' show JSON;
+import 'dart:core' hide Resource;
 
 import 'package:logging/logging.dart';
 

--- a/ide/web/lib/package_mgmt/bower_properties.dart
+++ b/ide/web/lib/package_mgmt/bower_properties.dart
@@ -6,6 +6,7 @@ library spark.package_mgmt.bower_properties;
 
 import 'dart:async';
 import 'dart:convert' show JSON;
+import 'dart:core' hide Resource;
 
 import 'package_manager.dart';
 import '../workspace.dart';

--- a/ide/web/lib/package_mgmt/package_manager.dart
+++ b/ide/web/lib/package_mgmt/package_manager.dart
@@ -6,6 +6,8 @@ library spark.package_mgmt;
 
 import 'dart:async';
 
+import 'dart:core' hide Resource;
+
 import '../builder.dart';
 import '../jobs.dart';
 import '../workspace.dart';

--- a/ide/web/lib/package_mgmt/package_utils.dart
+++ b/ide/web/lib/package_mgmt/package_utils.dart
@@ -4,6 +4,8 @@
 
 library spark.package_utils;
 
+import 'dart:core' hide Resource;
+
 import 'bower_properties.dart';
 import 'pub.dart';
 import '../workspace.dart';

--- a/ide/web/lib/package_mgmt/pub.dart
+++ b/ide/web/lib/package_mgmt/pub.dart
@@ -8,6 +8,7 @@
 library spark.package_mgmt.pub;
 
 import 'dart:async';
+import 'dart:core' hide Resource;
 
 import 'package:logging/logging.dart';
 import 'package:tavern/tavern.dart' as tavern;

--- a/ide/web/lib/scm.dart
+++ b/ide/web/lib/scm.dart
@@ -9,6 +9,7 @@
 library spark.scm;
 
 import 'dart:async';
+import 'dart:core' hide Resource;
 
 import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:intl/intl.dart';

--- a/ide/web/lib/search.dart
+++ b/ide/web/lib/search.dart
@@ -6,6 +6,7 @@ library spark.search;
 
 import 'dart:async';
 
+import 'dart:core' hide Resource;
 import 'package:spark_widgets/spark_suggest_box/spark_suggest_box.dart';
 
 import 'workspace.dart';

--- a/ide/web/lib/services.dart
+++ b/ide/web/lib/services.dart
@@ -5,6 +5,7 @@
 library spark.services;
 
 import 'dart:async';
+import 'dart:core' hide Resource;
 
 import 'package:logging/logging.dart';
 

--- a/ide/web/lib/templates/templates.dart
+++ b/ide/web/lib/templates/templates.dart
@@ -6,6 +6,7 @@ library spark.templates;
 
 import 'dart:async';
 import 'dart:convert' show JSON;
+import 'dart:core' hide Resource;
 import 'dart:html' hide File;
 
 import 'package:chrome/chrome_app.dart' as chrome;

--- a/ide/web/lib/ui/files_controller.dart
+++ b/ide/web/lib/ui/files_controller.dart
@@ -9,6 +9,7 @@ library spark.ui.files_controller;
 
 import 'dart:async';
 import 'dart:convert' show JSON;
+import 'dart:core' hide Resource;
 import 'dart:html' as html;
 
 import 'package:logging/logging.dart';

--- a/ide/web/lib/ui/widgets/file_item_cell.dart
+++ b/ide/web/lib/ui/widgets/file_item_cell.dart
@@ -8,6 +8,7 @@
 
 library spark.ui.widgets.fileitem_cell;
 
+import 'dart:core' hide Resource;
 import 'dart:html' hide File;
 
 import 'listview_cell.dart';

--- a/ide/web/lib/utils.dart
+++ b/ide/web/lib/utils.dart
@@ -487,10 +487,10 @@ String _removeExtPrefix(String str) {
   return str.replaceFirst(new RegExp("chrome-extension://[a-z0-9]+/"), "");
 }
 
-String _platform() {
-  String str = html.window.navigator.platform;
-  return (str != null) ? str.toLowerCase() : '';
-}
+// String _platform() {
+//   String str = html.window.navigator.platform;
+//   return (str != null) ? str.toLowerCase() : '';
+// }
 
 class FutureHelper {
   /**

--- a/ide/web/lib/workspace_search.dart
+++ b/ide/web/lib/workspace_search.dart
@@ -4,6 +4,8 @@
 
 library spark.workspace_search;
 
+import 'dart:core' hide Resource;
+
 import 'utils.dart';
 import 'workspace.dart';
 

--- a/ide/web/lib/workspace_utils.dart
+++ b/ide/web/lib/workspace_utils.dart
@@ -6,6 +6,7 @@ library spark.workspace_utils;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:core' hide Resource;
 
 import 'package:archive/archive.dart' as archive;
 import 'package:chrome/chrome_app.dart' as chrome;

--- a/ide/web/spark.dart
+++ b/ide/web/spark.dart
@@ -6,6 +6,7 @@ library spark;
 
 import 'dart:async';
 import 'dart:convert' show JSON;
+import 'dart:core' hide Resource;
 import 'dart:html' hide File;
 import 'dart:js' as js;
 

--- a/ide/web/test/app_test.dart
+++ b/ide/web/test/app_test.dart
@@ -52,7 +52,7 @@ defineTests() {
       try {
         app.start();
         expect(false, true, reason: 'expected start() to throw');
-      } on StateError catch (ex) {
+      } on StateError {
         expect(true, true);
       }
     });

--- a/ide/web/test/ui/ui_access.dart
+++ b/ide/web/test/ui/ui_access.dart
@@ -156,7 +156,7 @@ class DialogAccess {
   SparkDomAccess get _sparkDomAccess => SparkDomAccess.instance;
   SparkDialog get _dialog => _sparkDomAccess.getUIElement("#$id");
   List<SparkDialogButton> get _dialogButtons =>
-      _dialog.querySelectorAll("spark-dialog-button");
+      _dialog.querySelectorAll("spark-dialog-button") as List<SparkDialogButton>;
 
   DialogAccess(this.id) {
     SparkModal m = modalElement;

--- a/ide/web/test/workspace_test.dart
+++ b/ide/web/test/workspace_test.dart
@@ -5,6 +5,7 @@
 library spark.workspace_test;
 
 import 'dart:async';
+import 'dart:core' hide Resource;
 
 import 'package:chrome/chrome_app.dart' as chrome;
 import 'package:unittest/unittest.dart';


### PR DESCRIPTION
- add an `.analysis_options` file to exclude `build/` from analysis (new in recent dev sdks)
- ignore the `.packages` file (created by dev sdks)
- address analysis warnings related to exceptions caught but unused
- commented out some unused fields and methods
- added `import 'dart:core' hide Resource;` to all files that use the `Resource` class. The name conflicts with the new `Resource` class in `dart:core`.
- fixed issues where the `Element.classes.add()` method will now fail at runtime if a class name is passed in that has a space in it. We now pass in a list of styles instead: `classes.addAll([])`.

@ussuri 

:)