### PR TITLE
Fix flex items width in Chrome 48+

### DIFF
--- a/widgets/lib/common/spark_widget.css
+++ b/widgets/lib/common/spark_widget.css
@@ -9,6 +9,7 @@
 ::content * {
   box-sizing: border-box;
   outline: none;
+  min-width: 0;
 }
 
 /* NOTE: The font is set conservatively. Clients should make sure they specify


### PR DESCRIPTION
In Chrome 48 and later, (more/all) flex items have an implied minimum width of (essentially) "min-content". Chrome used to have a bug and did not apply that to all flex items; now it does. In this case, this minimum width is undesirable, so adding min-width: 0 here.

Chrome bug https://code.google.com/p/chromium/issues/detail?id=556379
See also https://www.chromestatus.com/feature/5651186401148928

Before:
![screenshot 2015-11-30 at 7 56 31 am](https://cloud.githubusercontent.com/assets/634478/11465576/483042dc-973a-11e5-9587-833efe16452e.png)


After:
![screenshot 2015-11-30 at 8 01 06 am](https://cloud.githubusercontent.com/assets/634478/11465579/4c8f4684-973a-11e5-92cf-265b83d08a13.png)
