### PR TITLE
Changed default Port for embedded web server

### DIFF
--- a/ide/web/lib/launch.dart
+++ b/ide/web/lib/launch.dart
@@ -554,7 +554,7 @@ class ChromeAppRemoteLaunchHandler extends LaunchTargetHandler {
  * machine.
  */
 class WebAppLocalLaunchHandler extends LaunchTargetHandler {
-  final int preferredPort = 51792;
+  final int preferredPort = 32345;
 
   final LaunchManager launchManager;
   final Workspace workspace;


### PR DESCRIPTION
According to https://developer.chrome.com/devtools/docs/remote-debugging#port-forwarding, port numbers must be between 1024 and 32767 (inclusive) in the Host field. 
Setting the port to `51792` makes it unavailable in Android.

I've picked one port that seems to be unassigned: http://www.speedguide.net/port.php?port=32345

