### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ## Chrome Dev Editor - a developer preview
 
-Chrome Dev Editor (CDE) is a developer tool for building apps on the Chrome platform - [Chrome Apps](https://developer.chrome.com/apps/about_apps) and Web Apps, in JavaScript or [Dart](https://www.dartlang.org/). CDE is built as a Chrome App written in Dart and uses Polymer. CDE runs on Windows, Mac, Linux, and Chrome OS! CDE supports Git, [Polymer](http://www.polymer-project.org/), and mobile development.
+Chrome Dev Editor (CDE) is a developer tool for building apps on the Chrome platform - [Chrome Apps](https://developer.chrome.com/apps/about_apps) and Web Apps, in JavaScript or [Dart](https://www.dartlang.org/). CDE is built as a Chrome App written in Dart and uses Polymer. CDE runs on Windows, Mac, Linux, and Chrome OS! CDE supports Git, [Polymer](https://www.polymer-project.org/), and mobile development.
 
 <a href="#">
 <img src="https://raw.githubusercontent.com/dart-lang/spark/master/doc/1px.png" width="220" height="0">
 </a>
-<a target="_blank" href="https://chrome.google.com/webstore/detail/spark/pnoffddplpippgcfjdhbmhkofpnaalpg">
+<a target="_blank" href="https://chrome.google.com/webstore/detail/chrome-dev-editor-develop/pnoffddplpippgcfjdhbmhkofpnaalpg">
 <img src="https://raw.githubusercontent.com/dart-lang/spark/master/doc/install-button.png">
 </a>
 
@@ -27,4 +27,4 @@ Read our [FAQ](doc/FAQ.md) to find out about CDE features, what’s coming up an
 
 ### Send Feedback
 
-We'd love to hear from you! Join our [G+ community](http://bit.ly/cdeusers) or [Mailing List](https://groups.google.com/a/chromium.org/forum/?hl=en#!forum/chromium-cde) to discuss your experiences with CDE. If you encounter a bug, or would like to see a new feature in CDE, file it as an issue with this [format](https://github.com/dart-lang/chromedeveditor/wiki/Reporting-a-problem) on our [GitHub issue tracker](https://github.com/dart-lang/spark/issues/new).
+We'd love to hear from you! Join our [G+ community](http://bit.ly/cdeusers) or [Mailing List](https://groups.google.com/a/chromium.org/forum/?hl=en#!forum/chromium-cde) to discuss your experiences with CDE. If you encounter a bug, or would like to see a new feature in CDE, file it as an issue with this [format](https://github.com/GoogleChrome/chromedeveditor/wiki/Reporting-a-problem) on our [GitHub issue tracker](https://github.com/dart-lang/spark/issues/new).


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/dart-lang/chromedeveditor/wiki/Reporting-a-problem | https://github.com/GoogleChrome/chromedeveditor/wiki/Reporting-a-problem 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://www.polymer-project.org/ | https://www.polymer-project.org/ 


### Other Corrected URLs 
Was | Now 
--- | --- 
https://chrome.google.com/webstore/detail/spark/pnoffddplpippgcfjdhbmhkofpnaalpg | https://chrome.google.com/webstore/detail/chrome-dev-editor-develop/pnoffddplpippgcfjdhbmhkofpnaalpg 
