### PR TITLE
Give App Nice Clean Name

### DIFF
--- a/ide/tool/release-config.json
+++ b/ide/tool/release-config.json
@@ -16,7 +16,7 @@
     "oauth2-clientid": "450494089748-v53iih45odoooegmomoij2do6eeok65m.apps.googleusercontent.com"
   },
   "stable": {
-    "name": "Chrome Dev Editor (developer preview)",
+    "name": "Chrome Dev Editor",
     "branch": "0.22",
     "version": "0.22",
     "id": "pnoffddplpippgcfjdhbmhkofpnaalpg",


### PR DESCRIPTION
Now Chrome Dev Editor is no longer being actively developed, it makes no sense to have the unsightly (developer preview) in the title of the stable build.

As such my proposed file change removes the (developer preview) to make the App have a nice and clean name within the Chrome environment.