### PR TITLE
use a custom version of compiler_unsupported

### DIFF
--- a/ide/pubspec.yaml
+++ b/ide/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   chrome_net: '>=0.1.0 <0.2.0'
   chrome_testing: '>=0.1.0 <0.2.0'
   cipher: '>=0.7.0 <0.8.0'
-  compiler_unsupported: 0.7.2
+  compiler_unsupported: 0.7.2+1
   crc32: any
   crypto: any
   diff: '>=0.1.0 <0.2.0'

--- a/ide/web/lib/editor_config.dart
+++ b/ide/web/lib/editor_config.dart
@@ -346,7 +346,6 @@ class GlobPattern implements Pattern {
 
     do {
       n = string.indexOf(globCharsRegExp, n);
-      GlobMatcher matcher;
 
       if (n == -1) {
         return new StaticMatcher(string, this, start, string.length);

--- a/ide/web/lib/files_mock.dart
+++ b/ide/web/lib/files_mock.dart
@@ -9,6 +9,7 @@ library spark.files_mock;
 
 import 'dart:async';
 import 'dart:html';
+import 'dart:js';
 
 import 'package:chrome/chrome_app.dart';
 import 'package:mime/mime.dart' as mime;
@@ -104,6 +105,9 @@ class MockFileSystem implements FileSystem {
     entry._modificationTime = new DateTime.fromMillisecondsSinceEpoch(
         entry._modificationTime.millisecondsSinceEpoch + 1);
   }
+
+  // Added to satisfy the analyzer.
+  JsObject blink_jsObject;
 }
 
 /**
@@ -248,6 +252,9 @@ abstract class _MockEntry implements Entry {
   String get _path => _parent == null ? '/${name}' : '${_parent._path}/${name}';
 
   int get _size;
+
+  // Added to satisfy the analyzer.
+  JsObject blink_jsObject;
 }
 
 class _MockFileEntry extends _MockEntry implements FileEntry, ChromeFileEntry {
@@ -316,6 +323,9 @@ class _MockFileEntry extends _MockEntry implements FileEntry, ChromeFileEntry {
 
   dynamic get jsProxy => null;
   dynamic toJs() => null;
+
+  // Added to satisfy the analyzer.
+  JsObject blink_jsObject;
 }
 
 class _MockDirectoryEntry extends _MockEntry implements DirectoryEntry {
@@ -453,6 +463,9 @@ class _MockDirectoryReader implements DirectoryReader {
   _MockDirectoryReader(this.dir);
 
   Future<List<Entry>> readEntries() => new Future.value(dir._children);
+
+  // Added to satisfy the analyzer.
+  JsObject blink_jsObject;
 }
 
 class _MockMetadata implements Metadata {
@@ -463,6 +476,9 @@ class _MockMetadata implements Metadata {
   DateTime get modificationTime => entry._modificationTime;
 
   int get size => entry._size;
+
+  // Added to satisfy the analyzer.
+  JsObject blink_jsObject;
 }
 
 abstract class _MockBlob implements Blob {
@@ -470,6 +486,9 @@ abstract class _MockBlob implements Blob {
   Blob slice([int start, int end, String contentType]);
   String get type;
   void close();
+
+  // Added to satisfy the analyzer.
+  JsObject blink_jsObject;
 }
 
 class _MockFile extends _MockBlob implements File {

--- a/ide/web/lib/package_mgmt/bower.dart
+++ b/ide/web/lib/package_mgmt/bower.dart
@@ -161,7 +161,7 @@ class _BowerBuilder extends PackageBuilder {
     // potentially shifting right under us now.
     for (ChangeDelta delta in event.changes) {
       Resource r = delta.resource;
-      if (delta.resource.name == properties.configFileName ||
+      if (r.name == properties.configFileName ||
           (delta.originalResource != null &&
            delta.originalResource.name == properties.configFileName)) {
         futures.add(_handleConfigFileChange(delta));

--- a/ide/web/lib/package_mgmt/bower_fetcher.dart
+++ b/ide/web/lib/package_mgmt/bower_fetcher.dart
@@ -188,7 +188,7 @@ class BowerFetcher {
     Map<String, dynamic> specMap;
     try {
       specMap = JSON.decode(spec);
-    } on FormatException catch (e, s) {
+    } on FormatException catch (e) {
       _logger.warning("Bad package spec: $e\n$spec");
       return [];
     }
@@ -528,7 +528,7 @@ class _Package {
       Map<String, dynamic> regInfo;
       try {
         regInfo = JSON.decode(regResponse);
-      } on FormatException catch (e) {
+      } on FormatException catch (_) {
         // Also handles [registryResponse]=='Package not found'.
         return _resolveWith(_Unresolved.STAR_PATH_FOR_UNKNOWN_PACKAGE);
       }
@@ -569,7 +569,7 @@ class _Package {
     } else {
       try {
         constraint = new semver.VersionConstraint.parse(hash);
-      } on FormatException catch (e) {
+      } on FormatException catch (_) {
         return _resolveWith(_Unresolved.MALFORMED_SPEC);
       }
     }
@@ -591,7 +591,7 @@ class _Package {
           if (constraint.allows(ver)) {
             candidateVersions.add(ver);
           }
-        } on FormatException catch (e) {
+        } on FormatException catch (_) {
           // Non-version looking tag. See if it matches literally.
           if (tagName == hash) {
             _resolvedDirectTag = tagName;

--- a/ide/web/lib/services/analyzer.dart
+++ b/ide/web/lib/services/analyzer.dart
@@ -43,12 +43,12 @@ class _NullDebugLogger implements _DebugLogger {
   void debug(String message) => null;
 }
 
-/**
- * Logger forwarding messages to the [print] method.
- */
-class _PrintDebugLogger implements _DebugLogger {
-  void debug(String message) => print(message);
-}
+// /**
+//  * Logger forwarding messages to the [print] method.
+//  */
+// class _PrintDebugLogger implements _DebugLogger {
+//   void debug(String message) => print(message);
+// }
 
 /**
  * Logger for the analysis engine messages, forwards all calls to


### PR DESCRIPTION
Fix an issue with building CDE w/ the latest Dart SDK. The `dart:profiler` has been removed, but the version of `compiler_unsupported` that we refer to uses it. This PR moves CDE to a patched version of `compiler_unsupported` that does not use `dart:profiler`.

- upgrade the `compiler_unsupported` dep
- fix some misc analysis issues