### PR TITLE
Attempt to fix drone.io build

### DIFF
--- a/ide/tool/drone_io.sh
+++ b/ide/tool/drone_io.sh
@@ -3,8 +3,8 @@
 if [ "$DRONE" = "true" ]; then
   sudo apt-get -y -q install zip
   sudo apt-get -y -q install libappindicator1
-  curl -O https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
-  sudo dpkg -i google-chrome-unstable_current_amd64.deb
+  curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  sudo dpkg -i google-chrome-stable_current_amd64.deb
   sudo start xvfb
   export HAS_DARTIUM=true
 fi


### PR DESCRIPTION
TBR

Chrome unstable is no longer compatible with libs installed on a standard drone.io instance: switching to Chrome stable to try.