### PR TITLE
Changed (again) preferred Port for web server

### DIFF
--- a/ide/web/lib/launch.dart
+++ b/ide/web/lib/launch.dart
@@ -554,7 +554,7 @@ class ChromeAppRemoteLaunchHandler extends LaunchTargetHandler {
  * machine.
  */
 class WebAppLocalLaunchHandler extends LaunchTargetHandler {
-  final int preferredPort = 32345;
+  final int preferredPort = 31999;
 
   final LaunchManager launchManager;
   final Workspace workspace;


### PR DESCRIPTION
I'm not sure why but the port I've chosen before doesn't work now. I've picked another that is free as well: http://www.speedguide.net/port.php?port=31999

![screenshot 2016-03-08 at 9 00 07 am](https://cloud.githubusercontent.com/assets/634478/13595601/08b93b60-e50d-11e5-945d-be906ef65fa4.png)

@ussuri 