### PR TITLE
Bower

### DIFF
--- a/ide/web/lib/package_mgmt/bower_fetcher.dart
+++ b/ide/web/lib/package_mgmt/bower_fetcher.dart
@@ -193,7 +193,15 @@ class BowerFetcher {
       return [];
     }
 
-    final Map<String, String> rawDeps = specMap['dependencies'];
+    Map<String, String> rawDeps = specMap['dependencies'];
+    Map<String, String> rawDevDeps = specMap['devDependencies'];
+    if (rawDevDeps != null) {
+      if (rawDeps != null) {
+        rawDeps.addAll(rawDevDeps);
+      } else {
+        rawDeps = rawDevDeps;
+      }
+    }
     if (rawDeps == null) return [];
 
     List<_Package> deps = [];
@@ -201,13 +209,6 @@ class BowerFetcher {
       deps.add(new _Package(name, fullPath));
     });
 
-    final Map<String, String> rawDevDeps = specMap['devDependencies'];
-    if (rawDevDeps != null) {
-      rawDevDeps.forEach((String name, String fullPath) {
-        deps.add(new _Package(name, fullPath));
-      });
-    };
-    
     return deps;
   }
 

--- a/ide/web/lib/package_mgmt/bower_fetcher.dart
+++ b/ide/web/lib/package_mgmt/bower_fetcher.dart
@@ -200,6 +200,14 @@ class BowerFetcher {
     rawDeps.forEach((String name, String fullPath) {
       deps.add(new _Package(name, fullPath));
     });
+
+    final Map<String, String> rawDevDeps = specMap['devDependencies'];
+    if (rawDevDeps != null) {
+      rawDevDeps.forEach((String name, String fullPath) {
+        deps.add(new _Package(name, fullPath));
+      });
+    };
+    
     return deps;
   }
 


### PR DESCRIPTION
Right now CDE do not recognize bower's `devDependencies` property. When trying to install/update bower it will only take dependencies from `dependencies` property.

This PR adds `devDependencies` to dependency list that being fetched so all dependencies are resolved correctly.